### PR TITLE
gpt-4-turbo-preview alias support

### DIFF
--- a/app/bot/settings_menu.py
+++ b/app/bot/settings_menu.py
@@ -11,7 +11,7 @@ GPT_MODELS_OPTIONS = {
 }
 
 GPT_MODELS_OPTIONS_PREVIEW = {
-    'gpt-4-1106-preview': 'GPT-4-Turbo',
+    'gpt-4-turbo-preview': 'GPT-4-Turbo',
     'gpt-4-vision-preview': 'GPT-4-Vision',
 }
 

--- a/app/bot/user_role_manager.py
+++ b/app/bot/user_role_manager.py
@@ -78,7 +78,7 @@ class UserRoleManager:
         #     commands += [
         #         types.BotCommand(command="/gpt3", description="set model to gpt-3.5-turbo"),
         #         types.BotCommand(command="/gpt4", description="set model to gpt-4"),
-        #         types.BotCommand(command="/gpt4turbo", description="set model to gpt-4-1106-preview"),
+        #         types.BotCommand(command="/gpt4turbo", description="set model to gpt-4-turbo-preview"),
         #         types.BotCommand(command="/gpt4vision", description="set model to gpt-4-vision-preview"),
         #     ]
 

--- a/app/context/context_manager.py
+++ b/app/context/context_manager.py
@@ -51,7 +51,7 @@ class ContextConfiguration:
                 summary_length=1024,
                 hard_max_context_size=9*1024,
             )
-        elif model == 'gpt-4-1106-preview':
+        elif model == 'gpt-4-turbo-preview':
             return ContextConfiguration(
                 model_name=model,
                 long_term_memory_tokens=512,

--- a/app/openai_helpers/chatgpt.py
+++ b/app/openai_helpers/chatgpt.py
@@ -16,7 +16,7 @@ class GptModel:
     GPT_35_TURBO = 'gpt-3.5-turbo'
     GPT_35_TURBO_16K = 'gpt-3.5-turbo-16k'
     GPT_4 = 'gpt-4'
-    GPT_4_TURBO_PREVIEW = 'gpt-4-1106-preview'
+    GPT_4_TURBO_PREVIEW = 'gpt-4-turbo-preview'
     GPT_4_VISION_PREVIEW = 'gpt-4-vision-preview'
 
 

--- a/app/openai_helpers/utils.py
+++ b/app/openai_helpers/utils.py
@@ -3,11 +3,12 @@ import openai
 
 
 COMPLETION_PRICE = {
-    'gpt-3.5-turbo': (Decimal('0.0015'), Decimal('0.002')),
+    'gpt-3.5-turbo': (Decimal('0.0005'), Decimal('0.0015')),
     'gpt-3.5-turbo-16k': (Decimal('0.003'), Decimal('0.004')),
     'gpt-4': (Decimal('0.03'), Decimal('0.06')),
     'gpt-4-1106-preview': (Decimal('0.01'), Decimal('0.03')),
     'gpt-4-vision-preview': (Decimal('0.01'), Decimal('0.03')),
+    'gpt-4-turbo-preview': (Decimal('0.01'), Decimal('0.03')),
 }
 
 WHISPER_PRICE = Decimal('0.006')

--- a/migrations/sql/0010_gpt_4_turbo_alias.sql
+++ b/migrations/sql/0010_gpt_4_turbo_alias.sql
@@ -1,0 +1,3 @@
+CREATE SCHEMA IF NOT EXISTS chatgpttg;
+
+UPDATE chatgpttg.user SET current_model = 'gpt-4-turbo-preview' WHERE current_model = 'gpt-4-1106-preview';


### PR DESCRIPTION
Now current_model=gpt-4-turbo-preview alias will be used for GPT-4 Turbo model. The latest stable version of the model will be automatically used (currently it's the new gpt-4-0125-preview).

Also gpt-3.5-turbo price is updated in the bot. Previous usage will be calculated incorrectly.