### PR TITLE
Add HTTP API for external message injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,38 @@ EXTRA_MODELS = [
 
 If you've done optional steps, when you send your first message to the bot, you will get a management message with your telegram id and info. You can use this message to setup your role as admin.
 
+**HTTP API for external message injection**
+
+The bot includes an optional HTTP API that lets external systems inject messages into conversations. The bot processes them through the full LLM pipeline and sends responses to Telegram.
+
+Use cases: external workers reacting to events (monitoring, CI/CD, webhooks), async tool results from long-running tasks.
+
+To enable, add to `settings_local.py`:
+```python
+HTTP_API_ENABLED = True
+HTTP_API_PORT = 8080
+HTTP_API_SECRET = 'your-hmac-secret-for-jwt'
+```
+
+Generate a JWT token and send a request:
+```bash
+TOKEN=$(python -c "import jwt; print(jwt.encode({'user_id': None}, 'your-hmac-secret-for-jwt', algorithm='HS256'))")
+
+# Fire-and-forget
+curl -X POST http://localhost:8080/api/v1/inject \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"chat_id": 123456789, "text": "Alert: server CPU at 95%"}'
+
+# Wait for LLM response
+curl -X POST http://localhost:8080/api/v1/inject \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"chat_id": 123456789, "text": "Summarize this", "wait_for_response": true}'
+```
+
+Supports text, images, and linked mode (subdialog via `reply_to_message_id`). See `specs/HTTP_API.md` for full documentation.
+
 🤖 **Commands**
 ```
 /reset - reset current dialog

--- a/app/api/headless_adapter.py
+++ b/app/api/headless_adapter.py
@@ -1,0 +1,94 @@
+import logging
+from io import BytesIO
+from contextlib import suppress
+from typing import Optional, Callable, List
+
+from aiogram import Bot
+from aiogram.utils.exceptions import CantParseEntities, BadRequest
+
+from app.context.context_manager import ContextManager
+from app.runtime.conversation_session import ConversationSession
+from app.runtime.events import (
+    StreamingContentDelta, FinalResponse,
+    FunctionCallCompleted, ErrorEvent,
+)
+from app.runtime.runtime import LLMRuntime
+from app.runtime.user_input import UserInput
+from app.storage.db import User
+
+from app.bot.telegram_runtime_adapter import TelegramRuntimeAdapter, TELEGRAM_MESSAGE_LENGTH_CUTOFF
+
+logger = logging.getLogger(__name__)
+
+
+class HeadlessSideEffectHandler:
+    def __init__(self, bot: Bot, chat_id: int):
+        self.bot = bot
+        self.chat_id = chat_id
+
+    async def send_message(self, text: str) -> int:
+        msg = await self.bot.send_message(self.chat_id, text)
+        return msg.message_id
+
+    async def send_photo(self, photo_bytes: bytes, caption: Optional[str] = None) -> int:
+        msg = await self.bot.send_photo(self.chat_id, BytesIO(photo_bytes), caption=caption)
+        return msg.message_id
+
+
+async def _send_headless_message(bot: Bot, chat_id: int, text: str, parse_mode=None):
+    try:
+        return await bot.send_message(chat_id, text, parse_mode=parse_mode)
+    except CantParseEntities:
+        return await bot.send_message(chat_id, text)
+
+
+class HeadlessRuntimeAdapter:
+    def __init__(self, bot: Bot, user: User, chat_id: int, context_manager: ContextManager):
+        self.bot = bot
+        self.user = user
+        self.chat_id = chat_id
+        self.context_manager = context_manager
+
+    async def handle_turn(
+        self,
+        runtime: LLMRuntime,
+        user_input: UserInput,
+        session: ConversationSession,
+        is_cancelled: Callable[[], bool],
+    ) -> dict:
+        response_text = ''
+        tg_message_ids: List[int] = []
+
+        async for event in runtime.process_turn(user_input, session, is_cancelled):
+            if isinstance(event, StreamingContentDelta):
+                continue
+
+            elif isinstance(event, FinalResponse):
+                final_dialog_message = event.dialog_message
+                if final_dialog_message and final_dialog_message.content:
+                    dialog_messages = TelegramRuntimeAdapter._split_dialog_message(final_dialog_message)
+                    for dm in dialog_messages:
+                        resp = await _send_headless_message(
+                            self.bot, self.chat_id, dm.content, parse_mode='Markdown'
+                        )
+                        tg_message_ids.append(resp.message_id)
+                        if event.needs_context_save:
+                            await self.context_manager.add_message(dm, resp.message_id)
+                    response_text = final_dialog_message.content
+
+            elif isinstance(event, FunctionCallCompleted):
+                if self.user.function_call_verbose:
+                    with suppress(BadRequest):
+                        text = f'Function call: {event.function_name}({event.function_args})\n\nResponse: {event.result}'
+                        text = text[:TELEGRAM_MESSAGE_LENGTH_CUTOFF]
+                        await _send_headless_message(self.bot, self.chat_id, text)
+
+            elif isinstance(event, ErrorEvent):
+                error_text = f'Error: {event.message}'
+                try:
+                    resp = await self.bot.send_message(self.chat_id, error_text)
+                    tg_message_ids.append(resp.message_id)
+                except Exception:
+                    logger.exception("Failed to send error message to chat %s", self.chat_id)
+
+        return {"response_text": response_text, "tg_message_ids": tg_message_ids}

--- a/app/api/http_api.py
+++ b/app/api/http_api.py
@@ -1,0 +1,157 @@
+import asyncio
+import logging
+from typing import Optional
+
+import jwt
+from aiohttp import web
+
+import settings
+from app.api.headless_adapter import HeadlessSideEffectHandler, HeadlessRuntimeAdapter
+from app.context.context_manager import build_context_manager
+from app.context.dialog_manager import DialogUtils
+from app.runtime.conversation_session import ConversationSession
+from app.runtime.default_runtime import DefaultLLMRuntime
+from app.runtime.user_input import UserInput, TextInput
+from app.storage.db import DB
+
+logger = logging.getLogger(__name__)
+
+
+def generate_api_token(user_id: int = None) -> str:
+    """Generate a JWT token. If user_id is None, creates a wildcard token."""
+    return jwt.encode({"user_id": user_id}, settings.HTTP_API_SECRET, algorithm="HS256")
+
+
+@web.middleware
+async def auth_middleware(request, handler):
+    if request.path == '/api/v1/health':
+        return await handler(request)
+
+    auth_header = request.headers.get('Authorization', '')
+    if not auth_header.startswith('Bearer '):
+        return web.json_response({"error": "Missing or invalid Authorization header"}, status=401)
+
+    token = auth_header[len('Bearer '):]
+    try:
+        payload = jwt.decode(token, settings.HTTP_API_SECRET, algorithms=["HS256"])
+    except jwt.InvalidTokenError:
+        return web.json_response({"error": "Invalid token"}, status=401)
+
+    request['jwt_payload'] = payload
+    return await handler(request)
+
+
+async def health_handler(request):
+    return web.json_response({"status": "ok"})
+
+
+async def inject_handler(request):
+    try:
+        body = await request.json()
+    except Exception:
+        return web.json_response({"error": "Invalid JSON"}, status=400)
+
+    chat_id = body.get('chat_id')
+    if chat_id is None:
+        return web.json_response({"error": "chat_id is required"}, status=400)
+
+    text = body.get('text')
+    images = body.get('images')
+    if not text and not images:
+        return web.json_response({"error": "At least text or images must be provided"}, status=400)
+
+    # JWT scope check
+    jwt_payload = request['jwt_payload']
+    jwt_user_id = jwt_payload.get('user_id')
+    if jwt_user_id is not None and jwt_user_id != chat_id:
+        return web.json_response({"error": "Token not authorized for this chat_id"}, status=403)
+
+    reply_to_message_id = body.get('reply_to_message_id')
+    wait_for_response = body.get('wait_for_response', False)
+
+    bot = request.app['bot']
+    db: DB = request.app['db']
+
+    user = await db.get_user(chat_id)
+    if user is None:
+        return web.json_response({"error": "User not found"}, status=404)
+
+    session = ConversationSession(
+        chat_id=chat_id,
+        reply_to_message_id=reply_to_message_id,
+    )
+
+    user_input = _build_user_input(text, images)
+
+    if wait_for_response:
+        result = await run_injection(bot, db, user, session, user_input, text, images)
+        return web.json_response({
+            "status": "ok",
+            "response_text": result["response_text"],
+            "tg_message_ids": result["tg_message_ids"],
+        })
+    else:
+        asyncio.create_task(run_injection(bot, db, user, session, user_input, text, images))
+        return web.json_response({"status": "accepted"}, status=202)
+
+
+def _build_user_input(text: Optional[str], images: Optional[list]) -> UserInput:
+    user_input = UserInput()
+
+    if images:
+        content = []
+        if text:
+            content.append(DialogUtils.construct_message_content_part(DialogUtils.CONTENT_TEXT, text))
+        for img in images:
+            url = img.get('url', '')
+            content.append(DialogUtils.construct_message_content_part(DialogUtils.CONTENT_IMAGE_URL, url))
+        user_input.text_inputs.append(TextInput(text=content if content else None))
+    elif text:
+        user_input.text_inputs.append(TextInput(text=text))
+
+    return user_input
+
+
+async def _echo_injected_message(bot, chat_id, text, images):
+    """Send the injected message to the chat so the user can see what triggered the response.
+
+    Returns the tg_message_id of the echo message.
+    """
+    parts = []
+    if text:
+        parts.append(text)
+    if images:
+        urls = [img.get('url', '') for img in images]
+        parts.append('\n'.join(f'🖼 {url}' for url in urls))
+
+    echo_text = f'📨 {chr(10).join(parts)}'
+    msg = await bot.send_message(chat_id, echo_text)
+    return msg.message_id
+
+
+async def run_injection(bot, db, user, session, user_input, text=None, images=None):
+    try:
+        echo_msg_id = await _echo_injected_message(bot, session.chat_id, text, images)
+
+        # Attach the real tg_message_id to user input so context tracks it correctly
+        for ti in user_input.text_inputs:
+            if ti.tg_message_id == -1:
+                ti.tg_message_id = echo_msg_id
+
+        context_manager = await build_context_manager(db, user, session)
+        side_effects = HeadlessSideEffectHandler(bot, session.chat_id)
+        runtime = DefaultLLMRuntime(db, user, side_effects, context_manager)
+        adapter = HeadlessRuntimeAdapter(bot, user, session.chat_id, context_manager)
+        return await adapter.handle_turn(runtime, user_input, session, lambda: False)
+    except Exception:
+        logger.exception("Error in run_injection for chat_id=%s", session.chat_id)
+        return {"response_text": "", "tg_message_ids": []}
+
+
+def create_api_app(bot, db) -> web.Application:
+    app = web.Application(middlewares=[auth_middleware])
+    app['bot'] = bot
+    app['db'] = db
+    app.router.add_get('/api/v1/health', health_handler)
+    app.router.add_post('/api/v1/inject', inject_handler)
+    return app

--- a/app/bot/telegram_bot.py
+++ b/app/bot/telegram_bot.py
@@ -44,6 +44,7 @@ class TelegramBot:
         self.role_manager = None
         self.monthly_usage_task = None
         self.batched_handler = None
+        self.api_runner = None
 
     async def on_startup(self, _):
         self.db = await DBFactory.create_database(
@@ -69,7 +70,18 @@ class TelegramBot:
         commands = self.role_manager.get_role_commands(UserRole.ADVANCED)
         await self.bot.set_my_commands(commands)
 
+        if settings.HTTP_API_ENABLED:
+            from app.api.http_api import create_api_app
+            import aiohttp.web
+            api_app = create_api_app(self.bot, self.db)
+            self.api_runner = aiohttp.web.AppRunner(api_app)
+            await self.api_runner.setup()
+            site = aiohttp.web.TCPSite(self.api_runner, '0.0.0.0', settings.HTTP_API_PORT)
+            await site.start()
+
     async def on_shutdown(self, _):
+        if self.api_runner:
+            await self.api_runner.cleanup()
         if self.monthly_usage_task:
             await self.monthly_usage_task.stop()
         await DBFactory().close_database()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     restart: always
     build: .
     image: chatgpt-tg
+    ports:
+      - "8080:8080"
     entrypoint: python main.py
     volumes:
       - ./:/usr/src/app/

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,5 +61,6 @@ typing_extensions==4.14.1
 urllib3==2.0.3
 uvicorn==0.35.0
 yarl==1.9.2
+PyJWT==2.9.0
 pytest==8.3.4
 pytest-asyncio==0.24.0

--- a/settings.py
+++ b/settings.py
@@ -118,6 +118,11 @@ VECTARA_CORPUS_ID = -1
 # Accepts LLModel instances or dicts (legacy format). See settings_local.py.example.
 EXTRA_MODELS: list = []
 
+# HTTP API (external message injection)
+HTTP_API_ENABLED = False
+HTTP_API_PORT = 8080
+HTTP_API_SECRET = ''  # HMAC-SHA256 secret for signing JWT tokens
+
 # Local overrides — create settings_local.py (gitignored) to override any setting
 try:
     from settings_local import *

--- a/settings_local.py.example
+++ b/settings_local.py.example
@@ -56,6 +56,15 @@ TELEGRAM_BOT_TOKEN = ''
 #     ),
 # ]
 
+# === HTTP API (external message injection) ===
+# HTTP_API_ENABLED = True
+# HTTP_API_PORT = 8080
+# HTTP_API_SECRET = 'your-hmac-secret-for-jwt'
+#
+# Generate tokens:
+#   python -c "import jwt; print(jwt.encode({'user_id': None}, 'your-hmac-secret-for-jwt', algorithm='HS256'))"
+#   python -c "import jwt; print(jwt.encode({'user_id': 123456789}, 'your-hmac-secret-for-jwt', algorithm='HS256'))"
+
 # === Extra LLM models (added without modifying llm_models.py) ===
 # from app.llm_models import LLModel, LLMPrice, LLMContextConfiguration, LLMCapabilities
 # from app.openai_helpers.llm_client import OpenAISpecificAsyncOpenAIClient, AnthropicAsyncClient

--- a/specs/HTTP_API.md
+++ b/specs/HTTP_API.md
@@ -1,0 +1,247 @@
+# HTTP API for External Message Injection
+
+> Inject messages into the bot from external systems via HTTP, with full LLM processing and Telegram delivery.
+
+---
+
+## 1. Overview
+
+The HTTP API allows external services to send messages into the bot as if a user had typed them in Telegram. The bot processes the injected message through the full LLM pipeline (context loading, function calling, streaming) and sends the response to the user's Telegram chat.
+
+**Use cases:**
+- **External workers** — react to events in external systems (monitoring alerts, CI/CD notifications, webhooks), send context to the bot, and have it respond intelligently in Telegram
+- **Async tool results** — the bot starts a long-running task via function calling; the result arrives later through the API
+
+The API reuses the existing transport-agnostic LLM Runtime layer (`app/runtime/`). No changes were needed in `ContextManager`, `DialogManager`, or `DefaultLLMRuntime`.
+
+---
+
+## 2. Architecture
+
+```
+External System
+      │
+      ▼  HTTP POST /api/v1/inject
+┌─────────────────────────────────────────────┐
+│  aiohttp server (same event loop as bot)    │
+│  ├── JWT auth middleware                     │
+│  └── inject_handler                         │
+│       ├── echo injected message to chat 📨  │
+│       ├── build ConversationSession          │
+│       ├── build UserInput                    │
+│       └── run_injection()                    │
+│            ├── build_context_manager()       │
+│            ├── DefaultLLMRuntime             │
+│            ├── HeadlessRuntimeAdapter        │
+│            │    └── consumes RuntimeEvents   │
+│            │         sends results to TG     │
+│            └── returns response_text + IDs   │
+└─────────────────────────────────────────────┘
+      │
+      ▼  Bot.send_message()
+   Telegram
+```
+
+### Package Structure
+
+```
+app/api/
+├── __init__.py
+├── headless_adapter.py    # HeadlessSideEffectHandler + HeadlessRuntimeAdapter
+└── http_api.py            # aiohttp app, JWT auth, inject handler, run_injection
+```
+
+### Key Components
+
+**`HeadlessSideEffectHandler`** — implements `SideEffectHandler` protocol via `Bot.send_message()` / `Bot.send_photo()` directly (no `aiogram.types.Message` needed).
+
+**`HeadlessRuntimeAdapter`** — consumes `RuntimeEvent`s from the runtime and sends results to Telegram as new messages (no streaming/editing). Simplified analog of `TelegramRuntimeAdapter`. Reuses `TelegramRuntimeAdapter._split_dialog_message()` for splitting long messages.
+
+**Echo message** — before LLM processing, the injected text is sent to the chat with a `📨` prefix so the user can see what triggered the response. The `tg_message_id` of the echo message is used for context chain tracking.
+
+---
+
+## 3. Configuration
+
+In `settings.py` / `settings_local.py`:
+
+```python
+HTTP_API_ENABLED = True        # Enable the HTTP API server
+HTTP_API_PORT = 8080           # Port to listen on
+HTTP_API_SECRET = 'your-secret'  # HMAC-SHA256 secret for JWT signing
+```
+
+The API server starts automatically with the bot when `HTTP_API_ENABLED = True`. It runs in the same event loop as aiogram polling — no separate process needed.
+
+---
+
+## 4. Authentication
+
+JWT tokens (HMAC-SHA256) are passed in the `Authorization: Bearer <token>` header.
+
+### Token Types
+
+| Token | JWT Payload | Scope |
+|-------|-------------|-------|
+| Wildcard | `{"user_id": null}` | Can inject to any `chat_id` |
+| User-scoped | `{"user_id": 123456}` | Can only inject to `chat_id == 123456` |
+
+### Generating Tokens
+
+```bash
+# Wildcard token
+python -c "import jwt; print(jwt.encode({'user_id': None}, 'your-secret', algorithm='HS256'))"
+
+# User-scoped token
+python -c "import jwt; print(jwt.encode({'user_id': 123456}, 'your-secret', algorithm='HS256'))"
+```
+
+Or programmatically:
+
+```python
+from app.api.http_api import generate_api_token
+token = generate_api_token()             # wildcard
+token = generate_api_token(user_id=123)  # user-scoped
+```
+
+### Auth Middleware Logic
+
+1. `/api/v1/health` — no auth required
+2. Decode JWT with `settings.HTTP_API_SECRET` (HS256)
+3. If `user_id` in payload is not null — verify `chat_id == user_id`, else 403
+4. If `user_id` is null — allow any `chat_id`
+
+---
+
+## 5. API Endpoints
+
+### `GET /api/v1/health`
+
+Health check. No authentication required.
+
+**Response:** `200 {"status": "ok"}`
+
+### `POST /api/v1/inject`
+
+Inject a message into the bot.
+
+**Request body:**
+
+```json
+{
+  "chat_id": 123456789,
+  "text": "Something happened",
+  "images": [{"url": "https://example.com/image.jpg"}],
+  "reply_to_message_id": null,
+  "wait_for_response": false
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `chat_id` | int | yes | Telegram chat ID (= `telegram_id` for private chats) |
+| `text` | string | no* | Message text |
+| `images` | list | no* | Images as URLs: `[{"url": "..."}]` |
+| `reply_to_message_id` | int | no | Linked mode: creates subdialog branching from this message |
+| `wait_for_response` | bool | no | `false` (default): fire-and-forget. `true`: wait for LLM response |
+
+\* At least `text` or `images` must be provided.
+
+**Responses:**
+
+| Status | When | Body |
+|--------|------|------|
+| 202 | `wait_for_response=false` | `{"status": "accepted"}` |
+| 200 | `wait_for_response=true` | `{"status": "ok", "response_text": "...", "tg_message_ids": [...]}` |
+| 400 | Missing fields / invalid JSON | `{"error": "..."}` |
+| 401 | Missing or invalid JWT | `{"error": "..."}` |
+| 403 | User-scoped token, wrong `chat_id` | `{"error": "..."}` |
+| 404 | `chat_id` not found in DB | `{"error": "User not found"}` |
+
+---
+
+## 6. Context Modes
+
+### Unlinked (default)
+
+When `reply_to_message_id` is omitted, `DialogManager` finds the last message in the chat (respecting `MESSAGE_EXPIRATION_WINDOW`) or starts a new dialog. This is the same behavior as sending a new message in Telegram.
+
+### Linked (subdialog)
+
+When `reply_to_message_id` is provided, `DialogManager` loads the message branch from that specific message — exactly like replying to a message in Telegram. The LLM sees only the context of that branch.
+
+### Cross-transport context
+
+Messages sent via Telegram and via the API share the same database and context. A message injected via API is visible in the context of subsequent Telegram messages, and vice versa.
+
+---
+
+## 7. Echo Message
+
+When a message is injected, the bot first sends the injected content to the Telegram chat with a `📨` prefix:
+
+```
+📨 Something happened
+```
+
+For images:
+
+```
+📨 Describe this
+🖼 https://example.com/image.jpg
+```
+
+This serves two purposes:
+1. The user sees what triggered the bot's response
+2. The `tg_message_id` of the echo message is used for context chain tracking, enabling correct subdialog branching
+
+---
+
+## 8. Pipeline
+
+```python
+async def run_injection(bot, db, user, session, user_input, text, images):
+    # 1. Echo the injected message to chat
+    echo_msg_id = await _echo_injected_message(bot, session.chat_id, text, images)
+
+    # 2. Attach tg_message_id for context tracking
+    for ti in user_input.text_inputs:
+        if ti.tg_message_id == -1:
+            ti.tg_message_id = echo_msg_id
+
+    # 3. Standard runtime pipeline (same as Telegram path)
+    context_manager = await build_context_manager(db, user, session)
+    side_effects = HeadlessSideEffectHandler(bot, session.chat_id)
+    runtime = DefaultLLMRuntime(db, user, side_effects, context_manager)
+    adapter = HeadlessRuntimeAdapter(bot, user, session.chat_id, context_manager)
+    return await adapter.handle_turn(runtime, user_input, session, lambda: False)
+```
+
+---
+
+## 9. Integration with Bot Lifecycle
+
+In `TelegramBot`:
+
+- **`on_startup`**: if `HTTP_API_ENABLED`, creates `aiohttp.web.Application`, sets up `AppRunner` + `TCPSite` on the configured port
+- **`on_shutdown`**: cleans up the API runner
+
+The aiohttp `TCPSite` runs in the same asyncio event loop as aiogram polling — no threading or multiprocessing.
+
+---
+
+## 10. Testing
+
+### Automated (E2E)
+
+`tests/e2e/test_http_api.py` — 23 tests covering:
+
+- Health endpoint (no auth)
+- Auth: missing header, invalid token, wrong secret, user-scoped token scope checks, wildcard token
+- Validation: missing chat_id, missing text/images, invalid JSON, unknown user
+- Injection: fire-and-forget (202), wait-for-response (200), LLM receives injected text, context persistence across injections, images (with text and without), linked mode with reply_to, cross-transport context (Telegram + API), echo message display, echo with images
+- Token generation utility
+
+### Manual
+
+`test_manual_callback.sh` — shell script for manual testing against a running bot instance. Generates JWT tokens and runs through all endpoint scenarios with curl.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,7 @@ settings.ENABLE_OBSIDIAN_ECHO_ADMIN_INTEGRATION = False
 settings.ENABLE_USER_ROLE_MANAGER_CHAT = False
 settings.MCP_SERVERS = []
 settings.EXTRA_MODELS = []
+settings.HTTP_API_ENABLED = False
 settings.IMAGE_PROXY_URL = 'http://localhost'
 settings.IMAGE_PROXY_PORT = 18321
 

--- a/tests/e2e/test_http_api.py
+++ b/tests/e2e/test_http_api.py
@@ -1,0 +1,507 @@
+import asyncio
+import json
+
+import jwt
+import pytest
+import pytest_asyncio
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+import settings
+from app.api.http_api import create_api_app, generate_api_token
+from app.openai_helpers.llm_client_factory import LLMClientFactory
+from tests.helpers.mock_llm_client import MockLLMClient
+from tests.helpers.telegram_factory import make_text_message
+from tests.helpers.bot_spy import BotSpy
+
+
+API_SECRET = 'test-secret-for-jwt'
+
+
+@pytest_asyncio.fixture
+async def api_client(bot_app):
+    """aiohttp TestClient wrapping the HTTP API app."""
+    telegram_bot, dp, mock_bot = bot_app
+    old_secret = settings.HTTP_API_SECRET
+    settings.HTTP_API_SECRET = API_SECRET
+    try:
+        api_app = create_api_app(mock_bot, telegram_bot.db)
+        async with TestClient(TestServer(api_app)) as client:
+            yield client, telegram_bot, dp, mock_bot
+    finally:
+        settings.HTTP_API_SECRET = old_secret
+
+
+def _wildcard_token():
+    return jwt.encode({"user_id": None}, API_SECRET, algorithm="HS256")
+
+
+def _user_token(user_id):
+    return jwt.encode({"user_id": user_id}, API_SECRET, algorithm="HS256")
+
+
+async def _create_user(dp, user_id):
+    """Send a message through dispatcher to create user in DB."""
+    mock_llm = MockLLMClient()
+    mock_llm.add_response("Init response")
+    LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm
+    update = make_text_message('init', user_id=user_id)
+    await dp.process_update(update)
+    await asyncio.sleep(0.1)
+
+
+class TestHealthEndpoint:
+
+    async def test_health_no_auth(self, api_client):
+        client, *_ = api_client
+        resp = await client.get('/api/v1/health')
+        assert resp.status == 200
+        data = await resp.json()
+        assert data['status'] == 'ok'
+
+
+class TestAuth:
+
+    async def test_missing_auth_header(self, api_client):
+        client, *_ = api_client
+        resp = await client.post('/api/v1/inject', json={"chat_id": 123, "text": "hi"})
+        assert resp.status == 401
+
+    async def test_invalid_token(self, api_client):
+        client, *_ = api_client
+        resp = await client.post(
+            '/api/v1/inject',
+            json={"chat_id": 123, "text": "hi"},
+            headers={"Authorization": "Bearer invalid.token.here"},
+        )
+        assert resp.status == 401
+
+    async def test_wrong_secret(self, api_client):
+        client, *_ = api_client
+        bad_token = jwt.encode({"user_id": None}, "wrong-secret", algorithm="HS256")
+        resp = await client.post(
+            '/api/v1/inject',
+            json={"chat_id": 123, "text": "hi"},
+            headers={"Authorization": f"Bearer {bad_token}"},
+        )
+        assert resp.status == 401
+
+    async def test_user_token_wrong_chat_id(self, api_client):
+        client, telegram_bot, dp, _ = api_client
+        user_id = 55501
+        await _create_user(dp, user_id)
+
+        token = _user_token(user_id)
+        resp = await client.post(
+            '/api/v1/inject',
+            json={"chat_id": 999999, "text": "hi"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status == 403
+
+    async def test_user_token_correct_chat_id(self, api_client):
+        client, telegram_bot, dp, _ = api_client
+        user_id = 55502
+        await _create_user(dp, user_id)
+
+        mock_llm = MockLLMClient()
+        mock_llm.add_response("API response")
+        LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm
+
+        token = _user_token(user_id)
+        resp = await client.post(
+            '/api/v1/inject',
+            json={"chat_id": user_id, "text": "hello", "wait_for_response": True},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status == 200
+
+    async def test_wildcard_token_any_chat_id(self, api_client):
+        client, telegram_bot, dp, _ = api_client
+        user_id = 55503
+        await _create_user(dp, user_id)
+
+        mock_llm = MockLLMClient()
+        mock_llm.add_response("Wildcard response")
+        LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm
+
+        token = _wildcard_token()
+        resp = await client.post(
+            '/api/v1/inject',
+            json={"chat_id": user_id, "text": "hello", "wait_for_response": True},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status == 200
+
+
+class TestValidation:
+
+    async def test_missing_chat_id(self, api_client):
+        client, *_ = api_client
+        token = _wildcard_token()
+        resp = await client.post(
+            '/api/v1/inject',
+            json={"text": "hi"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status == 400
+
+    async def test_missing_text_and_images(self, api_client):
+        client, *_ = api_client
+        token = _wildcard_token()
+        resp = await client.post(
+            '/api/v1/inject',
+            json={"chat_id": 123},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status == 400
+
+    async def test_invalid_json(self, api_client):
+        client, *_ = api_client
+        token = _wildcard_token()
+        resp = await client.post(
+            '/api/v1/inject',
+            data="not json",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+            },
+        )
+        assert resp.status == 400
+
+    async def test_user_not_found(self, api_client):
+        client, *_ = api_client
+        token = _wildcard_token()
+        resp = await client.post(
+            '/api/v1/inject',
+            json={"chat_id": 999888777, "text": "hello", "wait_for_response": True},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status == 404
+
+
+class TestInjectEndpoint:
+
+    async def test_echo_message_sent_to_chat(self, api_client):
+        """Injected text is echoed to chat with 📨 prefix before the LLM response."""
+        client, telegram_bot, dp, mock_bot = api_client
+        spy = BotSpy(mock_bot)
+        user_id = 55509
+        await _create_user(dp, user_id)
+        spy.mock_bot.request.reset_mock()
+
+        mock_llm = MockLLMClient()
+        mock_llm.add_response("Echo test response")
+        LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm
+
+        token = _wildcard_token()
+        await client.post(
+            '/api/v1/inject',
+            json={"chat_id": user_id, "text": "External event happened", "wait_for_response": True},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        sent_texts = spy.get_all_sent_texts()
+        # First message should be the echo
+        echo_msgs = [t for t in sent_texts if '📨' in t]
+        assert len(echo_msgs) >= 1
+        assert 'External event happened' in echo_msgs[0]
+        # Second should be the LLM response
+        spy.assert_sent_text_contains("Echo test response")
+
+    async def test_echo_message_with_images(self, api_client):
+        """Echo message includes image URLs when images are injected."""
+        client, telegram_bot, dp, mock_bot = api_client
+        spy = BotSpy(mock_bot)
+        user_id = 55508
+        await _create_user(dp, user_id)
+        spy.mock_bot.request.reset_mock()
+
+        mock_llm = MockLLMClient()
+        mock_llm.add_response("Saw image")
+        LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm
+
+        token = _wildcard_token()
+        await client.post(
+            '/api/v1/inject',
+            json={
+                "chat_id": user_id,
+                "text": "Check this",
+                "images": [{"url": "https://example.com/pic.png"}],
+                "wait_for_response": True,
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        sent_texts = spy.get_all_sent_texts()
+        echo_msgs = [t for t in sent_texts if '📨' in t]
+        assert len(echo_msgs) >= 1
+        assert 'Check this' in echo_msgs[0]
+        assert 'example.com/pic.png' in echo_msgs[0]
+
+    async def test_fire_and_forget(self, api_client):
+        client, telegram_bot, dp, mock_bot = api_client
+        spy = BotSpy(mock_bot)
+        user_id = 55510
+        await _create_user(dp, user_id)
+
+        mock_llm = MockLLMClient()
+        mock_llm.add_response("Fire and forget response")
+        LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm
+
+        token = _wildcard_token()
+        resp = await client.post(
+            '/api/v1/inject',
+            json={"chat_id": user_id, "text": "background task"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status == 202
+        data = await resp.json()
+        assert data['status'] == 'accepted'
+
+        # Wait for background task to complete
+        await asyncio.sleep(0.3)
+        spy.assert_sent_text_contains("Fire and forget response")
+
+    async def test_wait_for_response(self, api_client):
+        client, telegram_bot, dp, mock_bot = api_client
+        user_id = 55511
+        await _create_user(dp, user_id)
+
+        mock_llm = MockLLMClient()
+        mock_llm.add_response("Sync response text")
+        LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm
+
+        token = _wildcard_token()
+        resp = await client.post(
+            '/api/v1/inject',
+            json={"chat_id": user_id, "text": "sync request", "wait_for_response": True},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status == 200
+        data = await resp.json()
+        assert data['status'] == 'ok'
+        assert 'Sync response text' in data['response_text']
+        assert len(data['tg_message_ids']) >= 1
+
+    async def test_llm_receives_injected_text(self, api_client):
+        client, telegram_bot, dp, mock_bot = api_client
+        user_id = 55512
+        await _create_user(dp, user_id)
+
+        mock_llm = MockLLMClient()
+        mock_llm.add_response("Got it")
+        LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm
+
+        token = _wildcard_token()
+        resp = await client.post(
+            '/api/v1/inject',
+            json={"chat_id": user_id, "text": "Injected message content", "wait_for_response": True},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status == 200
+
+        assert len(mock_llm.calls) == 1
+        messages = mock_llm.calls[0]['messages']
+        user_msgs = [m for m in messages if m.get('role') == 'user']
+        assert any('Injected message content' in str(m.get('content', '')) for m in user_msgs)
+
+    async def test_response_saved_to_context(self, api_client):
+        """Injected message and response are saved — second inject sees conversation history."""
+        client, telegram_bot, dp, mock_bot = api_client
+        user_id = 55513
+        await _create_user(dp, user_id)
+
+        # First inject
+        mock_llm = MockLLMClient()
+        mock_llm.add_response("First API response")
+        LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm
+
+        token = _wildcard_token()
+        await client.post(
+            '/api/v1/inject',
+            json={"chat_id": user_id, "text": "First message", "wait_for_response": True},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        # Second inject — should see context from first
+        mock_llm2 = MockLLMClient()
+        mock_llm2.add_response("Second API response")
+        LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm2
+
+        await client.post(
+            '/api/v1/inject',
+            json={"chat_id": user_id, "text": "Second message", "wait_for_response": True},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+        assert len(mock_llm2.calls) == 1
+        messages = mock_llm2.calls[0]['messages']
+        all_content = ' '.join(str(m.get('content', '')) for m in messages)
+        assert 'First message' in all_content
+        assert 'First API response' in all_content
+
+    async def test_inject_with_images(self, api_client):
+        client, telegram_bot, dp, mock_bot = api_client
+        user_id = 55514
+        await _create_user(dp, user_id)
+
+        mock_llm = MockLLMClient()
+        mock_llm.add_response("I see the image")
+        LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm
+
+        token = _wildcard_token()
+        resp = await client.post(
+            '/api/v1/inject',
+            json={
+                "chat_id": user_id,
+                "text": "Look at this",
+                "images": [{"url": "https://example.com/image.jpg"}],
+                "wait_for_response": True,
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status == 200
+
+        # Verify LLM received multimodal content
+        assert len(mock_llm.calls) == 1
+        messages = mock_llm.calls[0]['messages']
+        user_msgs = [m for m in messages if m.get('role') == 'user']
+        assert len(user_msgs) >= 1
+        # Content should be a list (multimodal) containing image_url
+        last_user = user_msgs[-1]
+        content = last_user.get('content', '')
+        assert isinstance(content, list)
+        content_types = [part.get('type') for part in content]
+        assert 'image_url' in content_types
+
+    async def test_inject_images_only(self, api_client):
+        client, telegram_bot, dp, mock_bot = api_client
+        user_id = 55515
+        await _create_user(dp, user_id)
+
+        mock_llm = MockLLMClient()
+        mock_llm.add_response("Image only response")
+        LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm
+
+        token = _wildcard_token()
+        resp = await client.post(
+            '/api/v1/inject',
+            json={
+                "chat_id": user_id,
+                "images": [{"url": "https://example.com/photo.png"}],
+                "wait_for_response": True,
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status == 200
+
+    async def test_linked_mode_with_reply_to(self, api_client):
+        """Inject with reply_to_message_id creates a subdialog context."""
+        client, telegram_bot, dp, mock_bot = api_client
+        spy = BotSpy(mock_bot)
+        user_id = 55516
+        await _create_user(dp, user_id)
+
+        # Send first message via Telegram to establish context
+        mock_llm = MockLLMClient()
+        mock_llm.add_response("Original response")
+        LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm
+
+        update = make_text_message('Original question', user_id=user_id)
+        await dp.process_update(update)
+        await asyncio.sleep(0.1)
+
+        # Get the bot response message_id from spy
+        sent = spy.get_sent_messages()
+        # Find the response message (last sendMessage with the response text)
+        response_msgs = [m for m in sent if 'Original response' in m.get('text', '')]
+        assert len(response_msgs) > 0
+
+        # The tg_message_id in DB comes from the mock_bot.request return value
+        # We need to find the message_id that was stored in DB
+        user = await telegram_bot.db.get_user(user_id)
+        last_msg = await telegram_bot.db.get_last_message(user.id, user_id)
+        reply_to_id = last_msg.tg_message_id
+
+        # Now inject via API with reply_to_message_id
+        mock_llm2 = MockLLMClient()
+        mock_llm2.add_response("Subdialog reply")
+        LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm2
+
+        token = _wildcard_token()
+        resp = await client.post(
+            '/api/v1/inject',
+            json={
+                "chat_id": user_id,
+                "text": "Continue from here",
+                "reply_to_message_id": reply_to_id,
+                "wait_for_response": True,
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status == 200
+        data = await resp.json()
+        assert 'Subdialog reply' in data['response_text']
+
+        # Verify LLM got the context from the original message
+        assert len(mock_llm2.calls) == 1
+        messages = mock_llm2.calls[0]['messages']
+        all_content = ' '.join(str(m.get('content', '')) for m in messages)
+        assert 'Original response' in all_content
+
+    async def test_telegram_then_api_shared_context(self, api_client):
+        """Messages sent via Telegram and API share the same conversation context."""
+        client, telegram_bot, dp, mock_bot = api_client
+        user_id = 55517
+
+        # Message via Telegram
+        mock_llm = MockLLMClient()
+        mock_llm.add_response("Telegram response")
+        LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm
+
+        update = make_text_message('Telegram message', user_id=user_id)
+        await dp.process_update(update)
+        await asyncio.sleep(0.1)
+
+        # Message via API — should see Telegram context
+        mock_llm2 = MockLLMClient()
+        mock_llm2.add_response("API response")
+        LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm2
+
+        token = _wildcard_token()
+        resp = await client.post(
+            '/api/v1/inject',
+            json={"chat_id": user_id, "text": "API message", "wait_for_response": True},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status == 200
+
+        assert len(mock_llm2.calls) == 1
+        messages = mock_llm2.calls[0]['messages']
+        all_content = ' '.join(str(m.get('content', '')) for m in messages)
+        assert 'Telegram message' in all_content
+        assert 'Telegram response' in all_content
+
+
+class TestGenerateToken:
+
+    def test_generate_wildcard_token(self):
+        old_secret = settings.HTTP_API_SECRET
+        settings.HTTP_API_SECRET = API_SECRET
+        try:
+            token = generate_api_token()
+            payload = jwt.decode(token, API_SECRET, algorithms=["HS256"])
+            assert payload['user_id'] is None
+        finally:
+            settings.HTTP_API_SECRET = old_secret
+
+    def test_generate_user_token(self):
+        old_secret = settings.HTTP_API_SECRET
+        settings.HTTP_API_SECRET = API_SECRET
+        try:
+            token = generate_api_token(user_id=12345)
+            payload = jwt.decode(token, API_SECRET, algorithms=["HS256"])
+            assert payload['user_id'] == 12345
+        finally:
+            settings.HTTP_API_SECRET = old_secret


### PR DESCRIPTION
Optional aiohttp server (same event loop as bot) with JWT auth that allows external systems to inject messages into conversations. The bot processes them through the full LLM runtime pipeline and sends responses to Telegram with an echo of the injected message.

Supports text, images, fire-and-forget/sync modes, and linked subdialogs via reply_to_message_id.