### PR TITLE
Fix base64 image fetching by enabling image proxy URL fallback

### DIFF
--- a/app/bot/utils.py
+++ b/app/bot/utils.py
@@ -229,10 +229,10 @@ def generate_document_id(chat_id, message_id):
 def get_image_proxy_url():
     public_url = f'{settings.IMAGE_PROXY_URL}:{settings.IMAGE_PROXY_PORT}'
     docker_url = f'http://image_proxy:{settings.IMAGE_PROXY_BIND_PORT}'
-    # try:
-    #     requests.get(public_url)
-    # except requests.ConnectionError:
-    #     return docker_url
+    try:
+        requests.get(public_url)
+    except requests.ConnectionError:
+        return docker_url
     return public_url
 
 


### PR DESCRIPTION
Enable the commented-out fallback logic in get_image_proxy_url() that probes the public IMAGE_PROXY_URL and falls back to the Docker-internal hostname (http://image_proxy) when unreachable. This fixes httpx.ConnectError when models requiring base64 image input (e.g. Anthropic Claude) try to download images from within the Docker network.

https://claude.ai/code/session_01NdEDhPZYpn8gDox2BixbDY