### PR TITLE
Add per-model extra_completion_params to forward kwargs to completion…

### DIFF
--- a/app/llm_models.py
+++ b/app/llm_models.py
@@ -42,7 +42,7 @@ class LLModel:
     OPENROUTER_WIZARDLM2 = 'microsoft/wizardlm-2-8x22b'
 
     def __init__(self, *, model_name: str, api_key, context_configuration, model_readable_name=None, model_price=None, base_url=None,
-                 capabilities=None, minimum_user_role=UserRole.STRANGER, api_client=None):
+                 capabilities=None, minimum_user_role=UserRole.STRANGER, api_client=None, extra_completion_params=None):
         if model_readable_name is None:
             model_readable_name = model_name
 
@@ -64,6 +64,7 @@ class LLModel:
         self.capabilities = capabilities
         self.minimum_user_role = minimum_user_role
         self.api_client = api_client
+        self.extra_completion_params = extra_completion_params or {}
 
 
 @lru_cache

--- a/app/openai_helpers/llm_client.py
+++ b/app/openai_helpers/llm_client.py
@@ -4,12 +4,23 @@ import settings
 
 
 class BaseLLMClient:
-    def __init__(self, api_key, base_url=None):
+    def __init__(self, api_key, base_url=None, extra_completion_params=None):
         self.api_key = api_key
         self.base_url = base_url
+        self.extra_completion_params = extra_completion_params or {}
 
     async def chat_completions_create(self, model: str, messages, **additional_fields):
         raise NotImplementedError()
+
+    def _merge_extra_params(self, additional_fields):
+        if not self.extra_completion_params:
+            return additional_fields
+        merged = {**self.extra_completion_params, **additional_fields}
+        model_eb = self.extra_completion_params.get('extra_body')
+        call_eb = additional_fields.get('extra_body')
+        if isinstance(model_eb, dict) and isinstance(call_eb, dict):
+            merged['extra_body'] = {**model_eb, **call_eb}
+        return merged
 
 
 class GenericAsyncOpenAIClient(BaseLLMClient):
@@ -17,8 +28,8 @@ class GenericAsyncOpenAIClient(BaseLLMClient):
     The purpose of this client is to give a generic client for OpenAI compatible APIs
     without any specific OpenAI features.
     """
-    def __init__(self, api_key, base_url=None):
-        super().__init__(api_key, base_url)
+    def __init__(self, api_key, base_url=None, extra_completion_params=None):
+        super().__init__(api_key, base_url, extra_completion_params)
         if settings.LANGFUSE_ENABLED:
             from langfuse.openai import AsyncOpenAI
             self.client = AsyncOpenAI(api_key=api_key, base_url=base_url)
@@ -26,6 +37,7 @@ class GenericAsyncOpenAIClient(BaseLLMClient):
             self.client = openai.AsyncOpenAI(api_key=api_key, base_url=base_url)
 
     async def chat_completions_create(self, model: str, messages, **additional_fields):
+        additional_fields = self._merge_extra_params(additional_fields)
         if not settings.LANGFUSE_ENABLED:
             additional_fields.pop('metadata', None)
         return await self.client.chat.completions.create(model=model, messages=messages, **additional_fields)
@@ -36,10 +48,12 @@ class OpenAISpecificAsyncOpenAIClient(GenericAsyncOpenAIClient):
     This client is for OpenAI specific features.
     """
     async def chat_completions_create(self, model: str, messages, **additional_fields):
+        additional_fields = self._merge_extra_params(additional_fields)
         if not settings.LANGFUSE_ENABLED:
             additional_fields.pop('metadata', None)
         inner_additional_fields = {}
         if additional_fields.get("stream"):
+            additional_fields.pop("stream_options", None)
             inner_additional_fields["stream_options"] = {
                 "include_usage": True,
             }
@@ -52,11 +66,12 @@ class OpenAISpecificAsyncOpenAIClient(GenericAsyncOpenAIClient):
 
 
 class AnthropicAsyncClient(BaseLLMClient):
-    def __init__(self, api_key, base_url=None):
-        super().__init__(api_key, base_url)
+    def __init__(self, api_key, base_url=None, extra_completion_params=None):
+        super().__init__(api_key, base_url, extra_completion_params)
         self.client = anthropic.AsyncClient(api_key=api_key, base_url=base_url)
 
     async def chat_completions_create(self, model: str, messages, **additional_fields):
+        additional_fields = self._merge_extra_params(additional_fields)
         # find system prompt in messages
         system_prompt = None
         if len(messages) > 0 and messages[0]['role'] == 'system':

--- a/app/openai_helpers/llm_client_factory.py
+++ b/app/openai_helpers/llm_client_factory.py
@@ -13,5 +13,7 @@ class LLMClientFactory:
             }
             if llm_model.base_url:
                 params['base_url'] = llm_model.base_url
+            if llm_model.extra_completion_params:
+                params['extra_completion_params'] = llm_model.extra_completion_params
             cls._model_clients[model_name] = llm_model.api_client(**params)
         return cls._model_clients[model_name]

--- a/settings_local.py.example
+++ b/settings_local.py.example
@@ -75,5 +75,12 @@ TELEGRAM_BOT_TOKEN = ''
 #         capabilities=LLMCapabilities(
 #             streaming_responses=True,
 #         ),
+#         # Optional: arbitrary kwargs forwarded to chat.completions.create()
+#         # for this model. Use `extra_body` to pass vendor-specific params
+#         # (e.g. vLLM / SGLang chat_template_kwargs). Runtime values set by
+#         # the bot (tools, stream, metadata) take precedence over these.
+#         # extra_completion_params={
+#         #     'extra_body': {'chat_template_kwargs': {'enable_thinking': False}},
+#         # },
 #     ),
 # ]


### PR DESCRIPTION
… API

Lets users configure model-level kwargs (e.g. extra_body for vendor params like vLLM chat_template_kwargs) on LLModel / EXTRA_MODELS. Merged in at the client layer so it applies to both streaming calls and summarization.