### PR TITLE
Add function call hints and refactor streaming message handling

### DIFF
--- a/app/bot/service_message.py
+++ b/app/bot/service_message.py
@@ -1,0 +1,163 @@
+import logging
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+from aiogram.types import Message
+from aiogram.utils.exceptions import BadRequest
+
+from app.bot.utils import send_telegram_message, edit_telegram_message
+
+
+logger = logging.getLogger(__name__)
+
+
+class ServiceState(str, Enum):
+    IDLE = 'idle'
+    THINKING = 'thinking'
+    STREAMING = 'streaming'
+    STREAMING_OVERFLOW = 'streaming_overflow'
+    FUNCTION_HINT = 'function_hint'
+    FINAL = 'final'
+
+
+class ChatServiceMessage:
+    """One bot message kept attached to a chat across an LLM turn.
+
+    Provides set_text/finalize/clear helpers that prefer in-place edits
+    over send/delete cycles, with deduplication, optional throttling, and
+    BadRequest recovery.
+    """
+
+    def __init__(self, message: Message):
+        self.message = message
+        self.chat_id: int = message.chat.id
+        self.message_id: Optional[int] = None
+        self.current_text: Optional[str] = None
+        self.last_send_time: Optional[datetime] = None
+        self.frozen: bool = False
+        self.detached: bool = False
+
+    @property
+    def is_attached(self) -> bool:
+        return self.message_id is not None
+
+    @property
+    def is_detached(self) -> bool:
+        return self.detached
+
+    async def set_text(
+        self,
+        text: str,
+        *,
+        parse_mode: Optional[str] = None,
+        reply_markup=None,
+        throttle_seconds: float = 0,
+    ) -> Optional[int]:
+        """Send or edit the service message in place.
+
+        Returns the message_id, or None if both send and edit failed.
+        Skips silently if frozen / detached / dedup matches / throttled.
+        """
+        if self.frozen or self.detached:
+            return self.message_id
+
+        if self.current_text == text:
+            return self.message_id
+
+        if throttle_seconds > 0 and self.last_send_time is not None:
+            elapsed = (datetime.now() - self.last_send_time).total_seconds()
+            if elapsed < throttle_seconds:
+                return self.message_id
+
+        if self.message_id is None:
+            try:
+                response = await send_telegram_message(
+                    self.message, text, parse_mode=parse_mode, reply_markup=reply_markup,
+                )
+                self.message_id = response.message_id
+                self.current_text = text
+                self.last_send_time = datetime.now()
+            except BadRequest as e:
+                logger.warning("Failed to send service message: %s", e)
+        else:
+            try:
+                await edit_telegram_message(
+                    self.message, text, self.message_id,
+                    parse_mode=parse_mode, reply_markup=reply_markup,
+                )
+                self.current_text = text
+                self.last_send_time = datetime.now()
+            except BadRequest as e:
+                logger.warning(
+                    "Failed to edit service message %s: %s; invalidating",
+                    self.message_id, e,
+                )
+                self.message_id = None
+                self.current_text = None
+
+        return self.message_id
+
+    async def finalize(
+        self,
+        text: str,
+        *,
+        parse_mode: Optional[str] = None,
+        reply_markup=None,
+    ) -> Optional[int]:
+        """Write the final answer into the service message and detach.
+
+        After finalize the instance no longer touches the message
+        (subsequent set_text/clear become no-ops).
+        """
+        if self.detached:
+            return self.message_id
+
+        if self.message_id is None:
+            try:
+                response = await send_telegram_message(
+                    self.message, text, parse_mode=parse_mode, reply_markup=reply_markup,
+                )
+                self.message_id = response.message_id
+            except BadRequest as e:
+                logger.warning("Failed to send finalized service message: %s", e)
+                return None
+        else:
+            try:
+                await edit_telegram_message(
+                    self.message, text, self.message_id,
+                    parse_mode=parse_mode, reply_markup=reply_markup,
+                )
+            except BadRequest as e:
+                logger.warning(
+                    "Failed to edit service message %s on finalize: %s; sending fresh",
+                    self.message_id, e,
+                )
+                self.message_id = None
+                try:
+                    response = await send_telegram_message(
+                        self.message, text, parse_mode=parse_mode, reply_markup=reply_markup,
+                    )
+                    self.message_id = response.message_id
+                except BadRequest as e2:
+                    logger.warning("Failed to send replacement finalized message: %s", e2)
+                    return None
+
+        self.current_text = text
+        self.last_send_time = datetime.now()
+        self.detached = True
+        return self.message_id
+
+    def freeze(self) -> None:
+        self.frozen = True
+
+    async def clear(self) -> None:
+        """Delete the service message if still attached and not detached."""
+        if self.message_id is None or self.detached:
+            return
+        try:
+            await self.message.bot.delete_message(self.chat_id, self.message_id)
+        except BadRequest as e:
+            logger.warning("Failed to delete service message %s: %s", self.message_id, e)
+        self.message_id = None
+        self.current_text = None

--- a/app/bot/settings_menu.py
+++ b/app/bot/settings_menu.py
@@ -101,6 +101,7 @@ class Settings:
             'system_prompt_settings_enabled': OnOffSetting('User info saving', 'system_prompt_settings_enabled'),
             'tts-voice': ChoiceSetting('TTS voice', 'tts_voice', TTS_VOICES),
             'voice_as_prompt': OnOffSetting('Voice as prompt', 'voice_as_prompt'),
+            'function_call_hints': OnOffSetting('Function call hints', 'function_call_hints'),
             'function_call_verbose': OnOffSetting('Verbose function calls', 'function_call_verbose'),
             'streaming_answers': OnOffSetting('Streaming answers', 'streaming_answers'),
             'agent_mode': OnOffSetting('Agent mode', 'agent_mode'),

--- a/app/bot/telegram_runtime_adapter.py
+++ b/app/bot/telegram_runtime_adapter.py
@@ -1,12 +1,12 @@
 from contextlib import suppress
-from datetime import datetime
 from typing import Callable
 
 from aiogram.types import Message, ParseMode, InlineKeyboardMarkup
 from aiogram.utils.exceptions import BadRequest
 
 from app.bot.cancellation_manager import get_cancel_button
-from app.bot.utils import send_telegram_message, edit_telegram_message
+from app.bot.service_message import ChatServiceMessage, ServiceState
+from app.bot.utils import send_telegram_message
 from app.context.context_manager import ContextManager
 from app.runtime.conversation_session import ConversationSession
 from app.runtime.events import (
@@ -21,6 +21,7 @@ WAIT_BETWEEN_MESSAGE_UPDATES = 1
 TELEGRAM_MESSAGE_LENGTH_CUTOFF = 4080
 THINKING_EMOJI = '\U0001f9e0'
 THINKING_MAX_CHARS = 300
+MIN_STREAMING_CONTENT_LEN = 50
 
 
 def _format_thinking_display(thinking_text: str) -> str:
@@ -57,118 +58,114 @@ class TelegramRuntimeAdapter:
         session: ConversationSession,
         is_cancelled: Callable[[], bool],
     ):
-        message_id = None
-        chat_id = None
-        previous_content = None
-        previous_time = None
-        message_too_long_for_telegram = False
-        was_thinking = False
-        function_hint_message_id = None
+        service = ChatServiceMessage(self.message)
+        state = ServiceState.IDLE
+        typing_action_sent = False
 
         keyboard = InlineKeyboardMarkup()
         keyboard.add(get_cancel_button())
 
-        final_dialog_message = None
+        async def ensure_typing_action():
+            nonlocal typing_action_sent
+            if not typing_action_sent and service.is_attached:
+                with suppress(BadRequest):
+                    await self.message.bot.send_chat_action(service.chat_id, 'typing')
+                typing_action_sent = True
 
-        async for event in runtime.process_turn(user_input, session, is_cancelled):
-            if isinstance(event, StreamingContentDelta):
-                if message_too_long_for_telegram:
-                    continue
-
-                if event.is_thinking:
-                    was_thinking = True
-                    thinking_display = _format_thinking_display(event.thinking_text)
-                    if not message_id:
-                        resp = await send_telegram_message(self.message, thinking_display, reply_markup=keyboard)
-                        chat_id = self.message.chat.id
-                        await self.message.bot.send_chat_action(chat_id, 'typing')
-                        message_id = resp.message_id
-                        previous_content = thinking_display
-                        previous_time = datetime.now()
+        try:
+            async for event in runtime.process_turn(user_input, session, is_cancelled):
+                if isinstance(event, StreamingContentDelta):
+                    if state == ServiceState.STREAMING_OVERFLOW:
                         continue
 
-                    time_passed_seconds = (datetime.now() - previous_time).seconds
-                    if previous_content != thinking_display and time_passed_seconds >= WAIT_BETWEEN_MESSAGE_UPDATES:
-                        await self.message.bot.edit_message_text(thinking_display, chat_id, message_id, reply_markup=keyboard)
-                        previous_content = thinking_display
-                        previous_time = datetime.now()
-                    continue
+                    if event.is_thinking:
+                        thinking_display = _format_thinking_display(event.thinking_text)
+                        throttle = WAIT_BETWEEN_MESSAGE_UPDATES if state == ServiceState.THINKING else 0
+                        await service.set_text(
+                            thinking_display,
+                            reply_markup=keyboard,
+                            throttle_seconds=throttle,
+                        )
+                        state = ServiceState.THINKING
+                        await ensure_typing_action()
+                        continue
 
-                # Transition from thinking to normal content
-                if was_thinking:
-                    was_thinking = False
-                    previous_time = None
+                    new_content = ' '.join(event.visible_text.strip().split(' ')[:-1]) if event.visible_text else ''
+                    if len(new_content) < MIN_STREAMING_CONTENT_LEN:
+                        continue
 
-                new_content = ' '.join(event.visible_text.strip().split(' ')[:-1]) if event.visible_text else ''
-                if len(new_content) < 50:
-                    continue
-
-                if not message_id:
-                    resp = await send_telegram_message(self.message, new_content, reply_markup=keyboard)
-                    chat_id = self.message.chat.id
-                    await self.message.bot.send_chat_action(chat_id, 'typing')
-                    message_id = resp.message_id
-                    previous_content = new_content
-                    previous_time = datetime.now()
-                    continue
-
-                time_passed_seconds = (datetime.now() - previous_time).seconds if previous_time else WAIT_BETWEEN_MESSAGE_UPDATES
-                if previous_content != new_content and time_passed_seconds >= WAIT_BETWEEN_MESSAGE_UPDATES:
                     if len(new_content) > TELEGRAM_MESSAGE_LENGTH_CUTOFF:
-                        message_too_long_for_telegram = True
-                        new_content = f'{new_content[:TELEGRAM_MESSAGE_LENGTH_CUTOFF]} \u23f3...'
-                    await self.message.bot.edit_message_text(new_content, chat_id, message_id, reply_markup=keyboard)
-                    previous_content = new_content
-                    previous_time = datetime.now()
+                        truncated = f'{new_content[:TELEGRAM_MESSAGE_LENGTH_CUTOFF]} ⏳...'
+                        await service.set_text(truncated, reply_markup=keyboard)
+                        service.freeze()
+                        state = ServiceState.STREAMING_OVERFLOW
+                        await ensure_typing_action()
+                        continue
 
-            elif isinstance(event, FinalResponse):
-                final_dialog_message = event.dialog_message
+                    throttle = WAIT_BETWEEN_MESSAGE_UPDATES if state == ServiceState.STREAMING else 0
+                    await service.set_text(
+                        new_content,
+                        reply_markup=keyboard,
+                        throttle_seconds=throttle,
+                    )
+                    state = ServiceState.STREAMING
+                    await ensure_typing_action()
 
-                # Delete orphaned thinking message if no content to show (thinking-only + tool_call)
-                if message_id is not None and (not final_dialog_message or not final_dialog_message.content):
-                    with suppress(BadRequest):
-                        await self.message.bot.delete_message(chat_id, message_id)
+                elif isinstance(event, FinalResponse):
+                    final_dialog_message = event.dialog_message
 
-                if final_dialog_message and final_dialog_message.content:
-                    dialog_messages = self._split_dialog_message(final_dialog_message)
-                    for dm in dialog_messages:
-                        parse_mode = ParseMode.MARKDOWN
-                        if message_id is not None:
-                            response = await edit_telegram_message(self.message, dm.content, message_id, parse_mode)
-                            message_id = None
-                        else:
-                            response = await send_telegram_message(self.message, dm.content, parse_mode)
-                        # Save content message to context with real Telegram message_id
-                        if event.needs_context_save:
-                            await self.context_manager.add_message(dm, response.message_id)
+                    if final_dialog_message and final_dialog_message.content:
+                        dialog_messages = self._split_dialog_message(final_dialog_message)
+                        first, rest = dialog_messages[0], dialog_messages[1:]
 
-                # Reset streaming state for next round (after tool calls)
-                message_id = None
-                message_too_long_for_telegram = False
-                was_thinking = False
-                previous_content = None
-                previous_time = None
+                        finalize_id = await service.finalize(
+                            first.content,
+                            parse_mode=ParseMode.MARKDOWN,
+                            reply_markup=None,
+                        )
+                        if event.needs_context_save and finalize_id is not None:
+                            await self.context_manager.add_message(first, finalize_id)
 
-            elif isinstance(event, FunctionCallStarted):
-                if self.user.function_call_hints and function_hint_message_id is None:
-                    hint_text = event.status_message or f'Running {event.function_name}...'
-                    with suppress(BadRequest):
-                        resp = await send_telegram_message(self.message, hint_text, reply_markup=keyboard)
-                        if chat_id is None:
-                            chat_id = self.message.chat.id
-                        function_hint_message_id = resp.message_id
+                        for dm in rest:
+                            response = await send_telegram_message(
+                                self.message, dm.content, parse_mode=ParseMode.MARKDOWN,
+                            )
+                            if event.needs_context_save:
+                                await self.context_manager.add_message(dm, response.message_id)
 
-            elif isinstance(event, FunctionCallCompleted):
-                if function_hint_message_id is not None:
-                    with suppress(BadRequest):
-                        await self.message.bot.delete_message(chat_id, function_hint_message_id)
-                    function_hint_message_id = None
+                        # Detach the finalized message and start fresh for any
+                        # following phase (e.g. another agent iteration).
+                        service = ChatServiceMessage(self.message)
+                        typing_action_sent = False
+                        state = ServiceState.IDLE
+                    else:
+                        # Tool-only / empty response — keep service alive for next event.
+                        pass
 
-                if self.user.function_call_verbose:
-                    with suppress(BadRequest):
-                        function_response_text = f'Function call: {event.function_name}({event.function_args})\n\nResponse: {event.result}'
-                        function_response_text = function_response_text[:TELEGRAM_MESSAGE_LENGTH_CUTOFF]
-                        await send_telegram_message(self.message, function_response_text)
+                elif isinstance(event, FunctionCallStarted):
+                    if self.user.function_call_hints:
+                        hint_text = event.status_message or f'Running {event.function_name}...'
+                        await service.set_text(
+                            hint_text,
+                            reply_markup=keyboard,
+                            throttle_seconds=0,
+                        )
+                        state = ServiceState.FUNCTION_HINT
+                        await ensure_typing_action()
+
+                elif isinstance(event, FunctionCallCompleted):
+                    if self.user.function_call_verbose:
+                        with suppress(BadRequest):
+                            text = (
+                                f'Function call: {event.function_name}({event.function_args})'
+                                f'\n\nResponse: {event.result}'
+                            )
+                            text = text[:TELEGRAM_MESSAGE_LENGTH_CUTOFF]
+                            await send_telegram_message(self.message, text)
+        finally:
+            if state in (ServiceState.THINKING, ServiceState.STREAMING, ServiceState.FUNCTION_HINT) \
+                    and service.is_attached and not service.is_detached:
+                await service.clear()
 
     @staticmethod
     def _split_dialog_message(dialog_message, max_content_length=TELEGRAM_MESSAGE_LENGTH_CUTOFF):

--- a/app/bot/telegram_runtime_adapter.py
+++ b/app/bot/telegram_runtime_adapter.py
@@ -63,6 +63,7 @@ class TelegramRuntimeAdapter:
         previous_time = None
         message_too_long_for_telegram = False
         was_thinking = False
+        function_hint_message_id = None
 
         keyboard = InlineKeyboardMarkup()
         keyboard.add(get_cancel_button())
@@ -148,7 +149,21 @@ class TelegramRuntimeAdapter:
                 previous_content = None
                 previous_time = None
 
+            elif isinstance(event, FunctionCallStarted):
+                if self.user.function_call_hints and function_hint_message_id is None:
+                    hint_text = event.status_message or f'Running {event.function_name}...'
+                    with suppress(BadRequest):
+                        resp = await send_telegram_message(self.message, hint_text, reply_markup=keyboard)
+                        if chat_id is None:
+                            chat_id = self.message.chat.id
+                        function_hint_message_id = resp.message_id
+
             elif isinstance(event, FunctionCallCompleted):
+                if function_hint_message_id is not None:
+                    with suppress(BadRequest):
+                        await self.message.bot.delete_message(chat_id, function_hint_message_id)
+                    function_hint_message_id = None
+
                 if self.user.function_call_verbose:
                     with suppress(BadRequest):
                         function_response_text = f'Function call: {event.function_name}({event.function_args})\n\nResponse: {event.result}'

--- a/app/bot/utils.py
+++ b/app/bot/utils.py
@@ -144,13 +144,13 @@ async def send_telegram_message(message: types.Message, text: str, parse_mode=No
         return await send_message(text, reply_markup=reply_markup)
 
 
-async def edit_telegram_message(message: types.Message, text: str, message_id, parse_mode=None):
+async def edit_telegram_message(message: types.Message, text: str, message_id, parse_mode=None, reply_markup=None):
     chat_id = message.chat.id
     try:
-        return await message.bot.edit_message_text(text, chat_id, message_id,  parse_mode=parse_mode)
+        return await message.bot.edit_message_text(text, chat_id, message_id, parse_mode=parse_mode, reply_markup=reply_markup)
     except CantParseEntities:
         # try to edit message without parse_mode once
-        return await message.bot.edit_message_text(text, chat_id, message_id)
+        return await message.bot.edit_message_text(text, chat_id, message_id, reply_markup=reply_markup)
 
 
 async def send_photo(message: types.Message, photo_bytes, caption=None, reply_markup=None):

--- a/app/functions/agent_tools.py
+++ b/app/functions/agent_tools.py
@@ -56,6 +56,10 @@ class SpawnTask(AgentFunction):
             "Use SpawnTask for parallelizable work. Results arrive via <background-results> messages."
         )
 
+    @classmethod
+    def get_status_message(cls) -> str:
+        return 'Spawning sub-agent...'
+
 
 # --- WaitTask ---
 
@@ -76,6 +80,10 @@ class WaitTask(AgentFunction):
     def get_description(cls) -> str:
         return "Wait for any background task to complete. Blocks until at least one running task finishes, then returns status of all tasks. If no tasks are running, returns immediately."
 
+    @classmethod
+    def get_status_message(cls) -> str:
+        return 'Waiting for background tasks...'
+
 
 # --- CreatePlan ---
 
@@ -93,6 +101,10 @@ class CreatePlan(AgentFunction):
     @classmethod
     def get_description(cls) -> str:
         return "Create an execution plan with numbered steps. Replaces any existing active plan."
+
+    @classmethod
+    def get_status_message(cls) -> str:
+        return 'Creating plan...'
 
 
 # --- UpdatePlanStep ---
@@ -112,6 +124,10 @@ class UpdatePlanStep(AgentFunction):
     def get_description(cls) -> str:
         return "Update a plan step's status. The plan auto-completes when all steps are completed or skipped."
 
+    @classmethod
+    def get_status_message(cls) -> str:
+        return 'Updating plan...'
+
 
 # --- GetPlan ---
 
@@ -129,6 +145,10 @@ class GetPlan(AgentFunction):
     def get_description(cls) -> str:
         return "Retrieve the current execution plan with all steps and their statuses."
 
+    @classmethod
+    def get_status_message(cls) -> str:
+        return 'Reading plan...'
+
 
 # --- DeletePlan ---
 
@@ -145,6 +165,10 @@ class DeletePlan(AgentFunction):
     @classmethod
     def get_description(cls) -> str:
         return "Cancel and delete the current active plan."
+
+    @classmethod
+    def get_status_message(cls) -> str:
+        return 'Deleting plan...'
 
 
 # --- ScheduleTask ---
@@ -212,6 +236,10 @@ class ScheduleTask(OpenAIFunction):
         return "Schedule a task for later execution. Use 'once' with 'when' for one-time tasks, or 'recurring' with cron_expression for repeated tasks."
 
     @classmethod
+    def get_status_message(cls) -> str:
+        return 'Scheduling task...'
+
+    @classmethod
     def get_system_prompt_addition(cls) -> Optional[str]:
         return (
             "Use ScheduleTask for deferred execution. For one-time tasks use schedule_type='once' "
@@ -248,6 +276,10 @@ class ListScheduledTasks(OpenAIFunction):
     def get_description(cls) -> str:
         return "List all active scheduled tasks for this chat."
 
+    @classmethod
+    def get_status_message(cls) -> str:
+        return 'Listing scheduled tasks...'
+
 
 # --- CancelScheduledTask ---
 
@@ -265,6 +297,10 @@ class CancelScheduledTask(OpenAIFunction):
     @classmethod
     def get_description(cls) -> str:
         return "Cancel a scheduled task by its ID."
+
+    @classmethod
+    def get_status_message(cls) -> str:
+        return 'Cancelling scheduled task...'
 
 
 # Core agent tools (always registered)

--- a/app/functions/base.py
+++ b/app/functions/base.py
@@ -59,3 +59,12 @@ class OpenAIFunction(ABC):
         additional instructions about how to use this function.
         """
         return None
+
+    @classmethod
+    def get_status_message(cls) -> str:
+        """
+        Short, user-facing hint shown in chat while the function is running
+        (e.g. "Searching the web..."). Override per function for clarity.
+        """
+        name = cls.get_name().replace('_', ' ').strip()
+        return f'Running {name}...'

--- a/app/functions/dalle_3.py
+++ b/app/functions/dalle_3.py
@@ -76,6 +76,10 @@ class GenerateImageDalle3(OpenAIFunction):
         return "Use dalle-3 to generate image from prompt. Image prompt must be in english. Generate tailored detailed prompt for user idea."
 
     @classmethod
+    def get_status_message(cls) -> str:
+        return 'Generating image...'
+
+    @classmethod
     def get_system_prompt_addition(cls) -> Optional[str]:
         return "If user asks you to generate image, use some imagination and write a long 500 symbols good tailored detailed prompt for Dall-E 3 model and call function. Don't generate image if user didn't ask you to do so directly."
 

--- a/app/functions/mcp/mcp_function_storage.py
+++ b/app/functions/mcp/mcp_function_storage.py
@@ -83,6 +83,10 @@ class MCPFunction(OpenAIFunction):
     def get_system_prompt_addition(self) -> Optional[str]:
         return None
 
+    def get_status_message(self) -> str:
+        humanized = self.name.replace('_', ' ').replace('-', ' ').strip()
+        return f'Running {humanized}...'
+
 
 
 class MCPFunctionManager:

--- a/app/functions/obsidian_echo.py
+++ b/app/functions/obsidian_echo.py
@@ -39,3 +39,7 @@ class CreateObsidianNote(OpenAIFunction):
     @classmethod
     def get_system_prompt_addition(cls) -> Optional[str]:
         return "You can create notes in Obsidian notebook using the `create_obsidian_note` function if user asks you to do so."
+
+    @classmethod
+    def get_status_message(cls) -> str:
+        return 'Saving Obsidian note...'

--- a/app/functions/save_user_settings.py
+++ b/app/functions/save_user_settings.py
@@ -27,3 +27,7 @@ class SaveUserSettings(OpenAIFunction):
     @classmethod
     def get_description(cls) -> str:
         return "Save user info or user settings when user asks to do so. Rewrite the text of the UserSettings in system prompt."
+
+    @classmethod
+    def get_status_message(cls) -> str:
+        return 'Saving user info...'

--- a/app/functions/todoist.py
+++ b/app/functions/todoist.py
@@ -45,3 +45,7 @@ class TodoistAddTask(OpenAIFunction):
     @classmethod
     def get_system_prompt_addition(cls) -> Optional[str]:
         return "You have todoist integration. Todoist is integrated to user's calendar. Add tasks to todoist only if you asked to add task or calendar event. Don't ask for optional details, add task with minimum information."
+
+    @classmethod
+    def get_status_message(cls) -> str:
+        return 'Adding Todoist task...'

--- a/app/functions/vectara_search.py
+++ b/app/functions/vectara_search.py
@@ -53,3 +53,7 @@ class VectorSearch(OpenAIFunction):
     @classmethod
     def get_system_prompt_addition(cls):
         return 'You are an assistant tasked with helping user in working with documents. Your role involves extracting relevant information from provided documents to answer their questions. If the documents lack the necessary information, you must inform the office worker of this and then offer an answer based on common sense and your existing knowledge base if you have one.'
+
+    @classmethod
+    def get_status_message(cls) -> str:
+        return 'Searching documents...'

--- a/app/functions/wolframalpha.py
+++ b/app/functions/wolframalpha.py
@@ -52,3 +52,7 @@ class QueryWolframAlpha(OpenAIFunction):
     @classmethod
     def get_description(cls) -> str:
         return "Query WolframAlpha for currencies, weather, statistical info and math/calculus problems."
+
+    @classmethod
+    def get_status_message(cls) -> str:
+        return 'Querying WolframAlpha...'

--- a/app/runtime/agent_runtime.py
+++ b/app/runtime/agent_runtime.py
@@ -299,14 +299,24 @@ class AgentRuntime:
         function_name = function_call.name
         function_args = function_call.arguments
 
+        function_class = None
+        status_message = f'Running {function_name}...'
+        try:
+            function_class = function_storage.get_function_class(function_name)
+            status_message = function_class.get_status_message()
+        except Exception:
+            pass
+
         yield FunctionCallStarted(
             function_name=function_name,
             function_args=function_args,
             tool_call_id=tool_call_id,
+            status_message=status_message,
         )
 
         try:
-            function_class = function_storage.get_function_class(function_name)
+            if function_class is None:
+                function_class = function_storage.get_function_class(function_name)
             function = function_class(self.user, self.db, context_manager, self.side_effects, tool_call_id)
             function_response_raw = await function.run_str_args(function_args)
         except Exception as e:

--- a/app/runtime/default_runtime.py
+++ b/app/runtime/default_runtime.py
@@ -172,14 +172,24 @@ class DefaultLLMRuntime:
         function_name = function_call.name
         function_args = function_call.arguments
 
+        function_class = None
+        status_message = f'Running {function_name}...'
+        try:
+            function_class = function_storage.get_function_class(function_name)
+            status_message = function_class.get_status_message()
+        except Exception:
+            pass
+
         yield FunctionCallStarted(
             function_name=function_name,
             function_args=function_args,
             tool_call_id=tool_call_id,
+            status_message=status_message,
         )
 
         try:
-            function_class = function_storage.get_function_class(function_name)
+            if function_class is None:
+                function_class = function_storage.get_function_class(function_name)
             function = function_class(self.user, self.db, context_manager, self.side_effects, tool_call_id)
             function_response_raw = await function.run_str_args(function_args)
         except Exception as e:

--- a/app/runtime/events.py
+++ b/app/runtime/events.py
@@ -27,6 +27,7 @@ class FunctionCallStarted(RuntimeEvent):
     function_name: str
     function_args: str
     tool_call_id: Optional[str] = None
+    status_message: Optional[str] = None
 
 
 @dataclass

--- a/app/storage/db.py
+++ b/app/storage/db.py
@@ -26,6 +26,7 @@ class User(pydantic.BaseModel):
     role: Optional[UserRole]
     streaming_answers: bool
     function_call_verbose: bool
+    function_call_hints: bool = True
     image_generation: bool
     tts_voice: str
     system_prompt_settings: Optional[str]
@@ -82,14 +83,14 @@ class DB:
         full_name = $7, username = $8, role = $9, streaming_answers = $10,
         function_call_verbose = $11, image_generation = $12, tts_voice = $13,
         system_prompt_settings = $14, system_prompt_settings_enabled = $15,
-        agent_mode = $16 WHERE id = $17 RETURNING *'''
+        agent_mode = $16, function_call_hints = $17 WHERE id = $18 RETURNING *'''
         return User(**await self.connection_pool.fetchrow(
             sql, user.current_model, user.gpt_mode, user.forward_as_prompt,
             user.voice_as_prompt, user.use_functions, user.auto_summarize,
             user.full_name, user.username, user.role.value, user.streaming_answers,
             user.function_call_verbose, user.image_generation, user.tts_voice,
             user.system_prompt_settings, user.system_prompt_settings_enabled,
-            user.agent_mode, user.id,
+            user.agent_mode, user.function_call_hints, user.id,
         ))
 
     async def create_user(self, telegram_user_id: int, role: UserRole):

--- a/migrations/sql/0016_add_function_call_hints.sql
+++ b/migrations/sql/0016_add_function_call_hints.sql
@@ -1,0 +1,1 @@
+ALTER TABLE chatgpttg.user ADD COLUMN IF NOT EXISTS function_call_hints BOOLEAN NOT NULL DEFAULT TRUE;

--- a/tests/e2e/test_function_calling.py
+++ b/tests/e2e/test_function_calling.py
@@ -103,8 +103,8 @@ class TestFunctionCalling:
 
         spy.assert_sent_text_contains("Function call: save_user_settings")
 
-    async def test_function_call_hints_show_and_disappear(self, bot_app):
-        """With function_call_hints=True, bot sends a status hint that is deleted on completion."""
+    async def test_function_call_hint_is_overwritten_by_final_answer(self, bot_app):
+        """With hints on, the hint and the final answer share one message: hint is shown via edit, then final overwrites it via edit."""
         telegram_bot, dp, mock_bot = bot_app
         spy = BotSpy(mock_bot)
 
@@ -139,17 +139,74 @@ class TestFunctionCalling:
         mock_llm2.add_response(content="OK!")
         LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm2
 
+        deletes_before = len(spy.get_calls_for_method('deleteMessage'))
+
         update2 = make_text_message('Save my name as Hint', user_id=user_id)
         await dp.process_update(update2)
         await asyncio.sleep(0.2)
 
         # Hint message uses the function-specific status from SaveUserSettings
         spy.assert_sent_text_contains("Saving user info...")
+        # Final assistant text reaches the chat too
+        spy.assert_sent_text_contains("OK!")
 
-        # Hint message must be deleted after completion
-        delete_calls = spy.get_calls_for_method('deleteMessage')
-        assert len(delete_calls) >= 1, (
-            f"Expected at least one deleteMessage call after function completion, got: {delete_calls}"
+        # The hint must NOT be deleted — it gets edited into the final answer.
+        deletes_after = len(spy.get_calls_for_method('deleteMessage'))
+        assert deletes_after == deletes_before, (
+            "Service message should be reused via edit, not deleted. "
+            f"Before turn: {deletes_before}, after: {deletes_after}"
+        )
+
+    async def test_tool_only_response_does_not_delete_service_message(self, bot_app):
+        """When LLM produces a tool_call without content, the service message must not flicker."""
+        telegram_bot, dp, mock_bot = bot_app
+        spy = BotSpy(mock_bot)
+
+        user_id = 44449
+
+        mock_llm = MockLLMClient()
+        mock_llm.add_response("Hello!")
+        LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm
+
+        update = make_text_message('Hi', user_id=user_id)
+        await dp.process_update(update)
+        await asyncio.sleep(0.1)
+
+        user = await telegram_bot.db.get_user(user_id)
+        user.use_functions = True
+        user.system_prompt_settings_enabled = True
+        await telegram_bot.db.update_user(user)
+
+        deletes_before = len(spy.get_calls_for_method('deleteMessage'))
+
+        # Two consecutive tool calls before the final answer.
+        mock_llm2 = MockLLMClient()
+        for i, label in enumerate(('First', 'Second')):
+            mock_llm2.add_response(
+                content=None,
+                tool_calls=[{
+                    'id': f'call_chain_{i}',
+                    'function': {
+                        'name': 'save_user_settings',
+                        'arguments': json.dumps({'settings_text': f'Name: {label}'}),
+                    },
+                }],
+            )
+        mock_llm2.add_response(content="Done!")
+        LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm2
+
+        update2 = make_text_message('Update twice', user_id=user_id)
+        await dp.process_update(update2)
+        await asyncio.sleep(0.3)
+
+        spy.assert_sent_text_contains("Done!")
+
+        # Across the chained tool calls there must be no delete: the service
+        # message is reused via edit between phases.
+        deletes_after = len(spy.get_calls_for_method('deleteMessage'))
+        assert deletes_after == deletes_before, (
+            f"Expected no extra deleteMessage calls during chained tool calls, "
+            f"got {deletes_after - deletes_before} new"
         )
 
     async def test_function_call_hints_disabled(self, bot_app):
@@ -195,6 +252,33 @@ class TestFunctionCalling:
         assert not any('Saving user info...' in t for t in all_texts), (
             f"Expected no hint message when hints disabled, got: {all_texts}"
         )
+
+    async def test_long_final_response_splits_into_chunks(self, bot_app):
+        """Final response longer than the Telegram cutoff is split into multiple messages."""
+        telegram_bot, dp, mock_bot = bot_app
+        spy = BotSpy(mock_bot)
+
+        user_id = 44450
+
+        # ~ 6750 chars, well over the 4080 cutoff, splits into >= 2 chunks
+        long_content = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. " * 120
+
+        mock_llm = MockLLMClient()
+        mock_llm.add_response(long_content)
+        LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm
+
+        update = make_text_message('Tell a long story', user_id=user_id)
+        await dp.process_update(update)
+        await asyncio.sleep(0.2)
+
+        sends = spy.get_sent_messages()
+        long_sends = [m for m in sends if 'Lorem ipsum' in m.get('text', '')]
+        assert len(long_sends) >= 2, (
+            f"Expected long final to split into >= 2 messages, got {len(long_sends)}"
+        )
+        # No deletes — every chunk is a fresh send, the service message owns
+        # the first chunk.
+        assert len(spy.get_calls_for_method('deleteMessage')) == 0
 
     async def test_successive_function_call_limit(self, bot_app):
         """Exceeding SUCCESSIVE_FUNCTION_CALLS_LIMIT produces an error."""

--- a/tests/e2e/test_function_calling.py
+++ b/tests/e2e/test_function_calling.py
@@ -103,6 +103,99 @@ class TestFunctionCalling:
 
         spy.assert_sent_text_contains("Function call: save_user_settings")
 
+    async def test_function_call_hints_show_and_disappear(self, bot_app):
+        """With function_call_hints=True, bot sends a status hint that is deleted on completion."""
+        telegram_bot, dp, mock_bot = bot_app
+        spy = BotSpy(mock_bot)
+
+        user_id = 44447
+
+        mock_llm = MockLLMClient()
+        mock_llm.add_response("Hello!")
+        LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm
+
+        update = make_text_message('Hi', user_id=user_id)
+        await dp.process_update(update)
+        await asyncio.sleep(0.1)
+
+        user = await telegram_bot.db.get_user(user_id)
+        user.use_functions = True
+        user.system_prompt_settings_enabled = True
+        # function_call_hints defaults to True; assert it explicitly
+        assert user.function_call_hints is True
+        await telegram_bot.db.update_user(user)
+
+        mock_llm2 = MockLLMClient()
+        mock_llm2.add_response(
+            content=None,
+            tool_calls=[{
+                'id': 'call_hint',
+                'function': {
+                    'name': 'save_user_settings',
+                    'arguments': json.dumps({'settings_text': 'Name: Hint'}),
+                },
+            }],
+        )
+        mock_llm2.add_response(content="OK!")
+        LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm2
+
+        update2 = make_text_message('Save my name as Hint', user_id=user_id)
+        await dp.process_update(update2)
+        await asyncio.sleep(0.2)
+
+        # Hint message uses the function-specific status from SaveUserSettings
+        spy.assert_sent_text_contains("Saving user info...")
+
+        # Hint message must be deleted after completion
+        delete_calls = spy.get_calls_for_method('deleteMessage')
+        assert len(delete_calls) >= 1, (
+            f"Expected at least one deleteMessage call after function completion, got: {delete_calls}"
+        )
+
+    async def test_function_call_hints_disabled(self, bot_app):
+        """With function_call_hints=False, no hint message is sent."""
+        telegram_bot, dp, mock_bot = bot_app
+        spy = BotSpy(mock_bot)
+
+        user_id = 44448
+
+        mock_llm = MockLLMClient()
+        mock_llm.add_response("Hello!")
+        LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm
+
+        update = make_text_message('Hi', user_id=user_id)
+        await dp.process_update(update)
+        await asyncio.sleep(0.1)
+
+        user = await telegram_bot.db.get_user(user_id)
+        user.use_functions = True
+        user.system_prompt_settings_enabled = True
+        user.function_call_hints = False
+        await telegram_bot.db.update_user(user)
+
+        mock_llm2 = MockLLMClient()
+        mock_llm2.add_response(
+            content=None,
+            tool_calls=[{
+                'id': 'call_no_hint',
+                'function': {
+                    'name': 'save_user_settings',
+                    'arguments': json.dumps({'settings_text': 'Name: NoHint'}),
+                },
+            }],
+        )
+        mock_llm2.add_response(content="OK!")
+        LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm2
+
+        update2 = make_text_message('Save my name as NoHint', user_id=user_id)
+        await dp.process_update(update2)
+        await asyncio.sleep(0.2)
+
+        all_texts = spy.get_all_sent_texts() + spy.get_all_edited_texts()
+        assert not any('Saving user info...' in t for t in all_texts), (
+            f"Expected no hint message when hints disabled, got: {all_texts}"
+        )
+
     async def test_successive_function_call_limit(self, bot_app):
         """Exceeding SUCCESSIVE_FUNCTION_CALLS_LIMIT produces an error."""
         telegram_bot, dp, mock_bot = bot_app


### PR DESCRIPTION
## Summary
This PR introduces function call hints (status messages shown while functions execute) and refactors the streaming message handling in the Telegram adapter to use a new `ChatServiceMessage` class that manages message lifecycle more robustly.

## Key Changes

### New Features
- **Function call hints**: Display user-friendly status messages while functions are executing (e.g., "Saving user info...", "Searching the web...")
  - Added `function_call_hints` user setting (defaults to `True`)
  - Each function class can override `get_status_message()` to provide custom hints
  - Hints are shown via the service message and edited into the final answer when available

### Refactoring
- **New `ChatServiceMessage` class** (`app/bot/service_message.py`):
  - Encapsulates the lifecycle of a single bot message across an LLM turn
  - Provides `set_text()` for streaming updates with deduplication and throttling
  - Provides `finalize()` to write the final answer and detach
  - Provides `clear()` to delete the message if not finalized
  - Handles `BadRequest` exceptions gracefully with fallback logic
  - Introduces `ServiceState` enum to track message state (IDLE, THINKING, STREAMING, STREAMING_OVERFLOW, FUNCTION_HINT, FINAL)

- **Simplified `handle_turn()` in `TelegramRuntimeAdapter`**:
  - Replaced manual message tracking (message_id, chat_id, previous_content, previous_time) with `ChatServiceMessage` instance
  - Removed orphaned thinking message deletion logic (now handled by `clear()`)
  - Consolidated streaming update logic with consistent throttling
  - Added support for `FunctionCallStarted` events to display hints
  - Service message is reused across chained tool calls, then detached after final response

### Implementation Details
- `FunctionCallStarted` event now includes optional `status_message` field
- Both `DefaultRuntime` and `AgentRuntime` extract the status message from the function class before yielding the event
- `edit_telegram_message()` now accepts optional `reply_markup` parameter
- Added database migration to add `function_call_hints` column with default `TRUE`
- All function classes inherit a default `get_status_message()` implementation from `BaseFunction`
- Specific functions override with custom messages (e.g., SaveUserSettings → "Saving user info...")

### Testing
- Added comprehensive e2e tests covering:
  - Hint message reuse via edit (not delete) when final answer arrives
  - Tool-only responses without flickering
  - Hints disabled behavior
  - Long final responses split into chunks with proper message reuse

https://claude.ai/code/session_01A3L8qS2RHnzopMcVTcjEb2