### PR TITLE
Add current date to system prompt

### DIFF
--- a/app/context/context_manager.py
+++ b/app/context/context_manager.py
@@ -1,3 +1,4 @@
+import datetime
 from typing import List, Optional
 
 import settings
@@ -41,6 +42,9 @@ class ContextManager:
         if not gpt_mode:
             raise ValueError(f"Unknown GPT mode: {self.user.gpt_mode}")
         system_prompt = gpt_mode["system"]
+
+        now = datetime.datetime.now(settings.POSTGRES_TIMEZONE)
+        system_prompt += f'\n\nCurrent date: {now.strftime("%A, %Y-%m-%d")}'
 
         function_storage = await self.get_function_storage()
         if function_storage is not None:

--- a/tests/e2e/test_simple_message.py
+++ b/tests/e2e/test_simple_message.py
@@ -1,7 +1,9 @@
 import asyncio
+import datetime
 
 import pytest
 
+import settings
 from app.openai_helpers.llm_client_factory import LLMClientFactory
 from tests.helpers.mock_llm_client import MockLLMClient
 from tests.helpers.telegram_factory import make_text_message
@@ -76,5 +78,9 @@ class TestSimpleMessage:
         assert len(mock_llm.calls) == 1
         messages = mock_llm.calls[0]['messages']
         # First message is system prompt, last should contain user text
+        system_prompt = str(messages[0].get('content', ''))
+        assert messages[0].get('role') == 'system'
+        today = datetime.datetime.now(settings.POSTGRES_TIMEZONE)
+        assert f'Current date: {today.strftime("%A, %Y-%m-%d")}' in system_prompt
         user_messages = [m for m in messages if m.get('role') == 'user']
         assert any('What is 2+2?' in str(m.get('content', '')) for m in user_messages)


### PR DESCRIPTION
## Summary
Include the current date in the system prompt sent to LLMs so models are aware of today's date during conversations.

## Changes
- **`app/context/context_manager.py`**: Modified `get_system_prompt()` to append the current date (formatted as "Day, YYYY-MM-DD") to the system prompt using the configured `POSTGRES_TIMEZONE`
- **`tests/e2e/test_simple_message.py`**: Added test assertions to verify that:
  - The first message in the LLM call is a system prompt
  - The system prompt contains the current date in the expected format

## Implementation Details
- The date is appended to the system prompt with a double newline separator for clarity
- Uses `datetime.datetime.now(settings.POSTGRES_TIMEZONE)` to respect the application's configured timezone
- Date format: `"%A, %Y-%m-%d"` (e.g., "Monday, 2024-01-15")
- The test validates this behavior end-to-end by inspecting the messages passed to the mock LLM client

https://claude.ai/code/session_01MRnZwNG6eHb2uQz2qzFWaG