### PR TITLE
Carry creation-time conversation context into scheduled tasks

### DIFF
--- a/app/bot/scheduler_service.py
+++ b/app/bot/scheduler_service.py
@@ -89,7 +89,17 @@ class SchedulerService:
             # the task was created in (falls back to default context loading
             # for tasks created before context snapshots existed)
             user_input = UserInput(text_inputs=[
-                TextInput(text=f"[Scheduled task: {title}]\n{prompt}")
+                TextInput(text=(
+                    f'<scheduled_task_execution>\n'
+                    f'Scheduled task #{task_id} "{title}" is due NOW. This message is an automatic '
+                    f'trigger from the scheduler, not a user request.\n'
+                    f'The conversation above is historical context from when this task was created — '
+                    f'use it for reference only.\n'
+                    f'This task is already scheduled and has just fired: do NOT call ScheduleTask '
+                    f'for it again. Execute the task now and report the result.\n'
+                    f'Task instructions:\n{prompt}\n'
+                    f'</scheduled_task_execution>'
+                ))
             ])
             session = ConversationSession(
                 chat_id=chat_id,

--- a/app/bot/scheduler_service.py
+++ b/app/bot/scheduler_service.py
@@ -85,23 +85,34 @@ class SchedulerService:
             side_effects = BotSideEffectHandler(self.bot, chat_id)
             notify_msg_id = await side_effects.send_message(f"⏰ Scheduled task: {title}")
 
-            # Build synthetic input and session
+            # Build synthetic input and session; load the conversation branch
+            # the task was created in (falls back to default context loading
+            # for tasks created before context snapshots existed)
             user_input = UserInput(text_inputs=[
                 TextInput(text=f"[Scheduled task: {title}]\n{prompt}")
             ])
-            session = ConversationSession(chat_id=chat_id)
+            session = ConversationSession(
+                chat_id=chat_id,
+                context_message_ids=task_record.get('context_message_ids') or None,
+            )
 
             # Run full agent turn
             context_manager = await build_context_manager(self.db, user, session)
             runtime = AgentRuntime(self.db, user, side_effects, context_manager)
 
-            final_text = ""
+            final_event = None
             async for event in runtime.process_turn(user_input, session, lambda: False):
                 if isinstance(event, FinalResponse) and event.dialog_message.content:
-                    final_text = event.dialog_message.get_text_content()
+                    final_event = event
 
-            if final_text:
-                await self.bot.send_message(chat_id, final_text)
+            if final_event is not None:
+                final_text = final_event.dialog_message.get_text_content()
+                if final_text:
+                    sent_message_id = await side_effects.send_message(final_text)
+                    if final_event.needs_context_save:
+                        # persist the result into the dialog branch so the user
+                        # can reply to it and continue the conversation
+                        await context_manager.add_message(final_event.dialog_message, sent_message_id)
 
             logger.info(f"Scheduled task {task_id} '{title}' executed for chat {chat_id}")
 

--- a/app/bot/scheduler_service.py
+++ b/app/bot/scheduler_service.py
@@ -9,6 +9,7 @@ from aiogram import Bot
 import settings
 from app.bot.bot_side_effects import BotSideEffectHandler
 from app.context.context_manager import build_context_manager
+from app.functions.agent_tools import get_user_timezone
 from app.runtime.agent_runtime import AgentRuntime
 from app.runtime.conversation_session import ConversationSession
 from app.runtime.events import FinalResponse
@@ -19,9 +20,13 @@ logger = logging.getLogger(__name__)
 
 
 def compute_next_cron(cron_expression: str, base_time: datetime = None) -> datetime:
-    """Compute next execution time from a cron expression."""
+    """Compute next execution time from a cron expression.
+
+    Cron wall times are interpreted in settings.USER_TIMEZONE, so schedules stay on
+    the configured local clock across DST shifts.
+    """
     if base_time is None:
-        base_time = datetime.now(timezone.utc)
+        base_time = datetime.now(get_user_timezone())
     return croniter(cron_expression, base_time).get_next(datetime)
 
 
@@ -69,7 +74,7 @@ class SchedulerService:
             if task_record['schedule_type'] == 'once':
                 await self.db.disable_scheduled_task(task_id)
             else:
-                next_exec = compute_next_cron(task_record['cron_expression'], now)
+                next_exec = compute_next_cron(task_record['cron_expression'])
                 await self.db.update_scheduled_task_execution(task_id, now, next_exec)
 
             user = await self.db.get_user_by_id(task_record['user_id'])

--- a/app/context/dialog_manager.py
+++ b/app/context/dialog_manager.py
@@ -20,6 +20,12 @@ class DialogManager:
     async def process_dialog(self, session: ConversationSession) -> List[DialogMessage]:
         self.chat_id = session.chat_id
 
+        if session.context_message_ids:
+            # explicit branch requested (e.g. scheduled task firing with its creation-time context)
+            dialog_messages = await self.db.get_messages_by_ids(session.context_message_ids)
+            self.messages = await self.summarize_messages_if_needed(dialog_messages)
+            return self.get_dialog_messages()
+
         if session.reply_to_message_id is not None and not session.is_forwarded:
             is_reply = True
             db_message = await self.db.get_telegram_message(self.chat_id, session.reply_to_message_id)

--- a/app/functions/agent_tools.py
+++ b/app/functions/agent_tools.py
@@ -264,7 +264,10 @@ class ScheduleTask(OpenAIFunction):
         return (
             "Use ScheduleTask for deferred execution. For one-time tasks use schedule_type='once' "
             "with natural language 'when'. For recurring use schedule_type='recurring' with cron_expression. "
-            "Use ListScheduledTasks/CancelScheduledTask to manage."
+            "Use ListScheduledTasks/CancelScheduledTask to manage. "
+            "When you receive a <scheduled_task_execution> message, a previously scheduled task has fired: "
+            "execute its instructions immediately — never call ScheduleTask to re-schedule it "
+            "(recurring tasks re-schedule themselves automatically)."
         )
 
 

--- a/app/functions/agent_tools.py
+++ b/app/functions/agent_tools.py
@@ -184,6 +184,25 @@ class ScheduleTaskParams(OpenAIFunctionParams):
 class ScheduleTask(OpenAIFunction):
     PARAMS_SCHEMA = ScheduleTaskParams
 
+    def _snapshot_context_message_ids(self) -> list:
+        """Snapshot the current dialog branch so the task fires with the conversation it was born in.
+
+        Trailing messages of an unfinished tool exchange (including the ScheduleTask call itself)
+        are trimmed — the stored branch must end on a plain user/assistant message to be a valid
+        LLM context on its own.
+        """
+        dialog_manager = self.context_manager.dialog_manager
+        if dialog_manager is None or not dialog_manager.messages:
+            return []
+        messages = list(dialog_manager.messages)
+        while messages and (
+            messages[-1].message.role in ('tool', 'function')
+            or messages[-1].message.tool_calls
+            or messages[-1].message.function_call
+        ):
+            messages.pop()
+        return [m.id for m in messages]
+
     async def run(self, params: ScheduleTaskParams) -> Optional[str]:
         from datetime import datetime, timezone
         from croniter import croniter
@@ -227,6 +246,7 @@ class ScheduleTask(OpenAIFunction):
             run_at=run_at,
             cron_expression=cron_expression,
             next_execution=next_execution,
+            context_message_ids=self._snapshot_context_message_ids(),
         )
         next_str = next_execution.strftime('%Y-%m-%d %H:%M UTC')
         return f"Scheduled task #{record['id']} '{params.title}' created. Next execution: {next_str}"

--- a/app/functions/agent_tools.py
+++ b/app/functions/agent_tools.py
@@ -1,13 +1,27 @@
+import logging
 from dataclasses import dataclass
 from typing import Optional, List, ClassVar
 
 import pydantic
+import pytz
 from pydantic import Field
 
+import settings
 from app.functions.base import OpenAIFunction, OpenAIFunctionParams
 from app.runtime.background_task_manager import BackgroundTaskManager
 from app.runtime.plan_manager import PlanManager
 from app.runtime.side_effects import SideEffectHandler
+
+logger = logging.getLogger(__name__)
+
+
+def get_user_timezone():
+    """Resolve settings.USER_TIMEZONE to a tzinfo, falling back to UTC on invalid values."""
+    try:
+        return pytz.timezone(settings.USER_TIMEZONE)
+    except pytz.UnknownTimeZoneError:
+        logger.warning(f"Invalid USER_TIMEZONE '{settings.USER_TIMEZONE}', falling back to UTC")
+        return pytz.utc
 
 
 @dataclass
@@ -210,6 +224,8 @@ class ScheduleTask(OpenAIFunction):
 
         chat_id = self.context_manager.session.chat_id
         now = datetime.now(timezone.utc)
+        user_tz = get_user_timezone()
+        local_now = datetime.now(user_tz)
 
         if params.schedule_type == 'once':
             if not params.when:
@@ -217,6 +233,9 @@ class ScheduleTask(OpenAIFunction):
             parsed = dateparser.parse(params.when, settings={
                 'PREFER_DATES_FROM': 'future',
                 'RETURN_AS_TIMEZONE_AWARE': True,
+                'TIMEZONE': str(user_tz),
+                'TO_TIMEZONE': 'UTC',
+                'RELATIVE_BASE': local_now.replace(tzinfo=None),
             })
             if parsed is None:
                 return f"Error: Could not parse date/time from '{params.when}'"
@@ -229,7 +248,7 @@ class ScheduleTask(OpenAIFunction):
             if not params.cron_expression:
                 return "Error: cron_expression is required for recurring tasks"
             try:
-                next_execution = croniter(params.cron_expression, now).get_next(datetime)
+                next_execution = croniter(params.cron_expression, local_now).get_next(datetime)
             except (ValueError, KeyError) as e:
                 return f"Error: Invalid cron expression: {e}"
             run_at = None
@@ -248,7 +267,7 @@ class ScheduleTask(OpenAIFunction):
             next_execution=next_execution,
             context_message_ids=self._snapshot_context_message_ids(),
         )
-        next_str = next_execution.strftime('%Y-%m-%d %H:%M UTC')
+        next_str = next_execution.astimezone(user_tz).strftime('%Y-%m-%d %H:%M') + f' ({user_tz})'
         return f"Scheduled task #{record['id']} '{params.title}' created. Next execution: {next_str}"
 
     @classmethod
@@ -264,6 +283,8 @@ class ScheduleTask(OpenAIFunction):
         return (
             "Use ScheduleTask for deferred execution. For one-time tasks use schedule_type='once' "
             "with natural language 'when'. For recurring use schedule_type='recurring' with cron_expression. "
+            f"Times in 'when' and cron expressions are interpreted in the bot's timezone ({settings.USER_TIMEZONE}): "
+            "pass the user's times as-is, do not convert them to UTC. "
             "Use ListScheduledTasks/CancelScheduledTask to manage. "
             "When you receive a <scheduled_task_execution> message, a previously scheduled task has fired: "
             "execute its instructions immediately — never call ScheduleTask to re-schedule it "
@@ -285,10 +306,11 @@ class ListScheduledTasks(OpenAIFunction):
         tasks = await self.db.get_scheduled_tasks(chat_id, enabled_only=True)
         if not tasks:
             return "No scheduled tasks."
-        lines = ["Scheduled tasks:"]
+        user_tz = get_user_timezone()
+        lines = [f"Scheduled tasks (times in {user_tz}):"]
         for t in tasks:
-            schedule_info = t.get('cron_expression') or (t['run_at'].strftime('%Y-%m-%d %H:%M') if t.get('run_at') else '?')
-            next_exec = t['next_execution'].strftime('%Y-%m-%d %H:%M') if t.get('next_execution') else '?'
+            schedule_info = t.get('cron_expression') or (t['run_at'].astimezone(user_tz).strftime('%Y-%m-%d %H:%M') if t.get('run_at') else '?')
+            next_exec = t['next_execution'].astimezone(user_tz).strftime('%Y-%m-%d %H:%M') if t.get('next_execution') else '?'
             lines.append(
                 f"  #{t['id']} [{t['schedule_type']}] {t['title']} "
                 f"(schedule: {schedule_info}, next: {next_exec})"

--- a/app/runtime/conversation_session.py
+++ b/app/runtime/conversation_session.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional
+from typing import List, Optional
 
 
 @dataclass
@@ -8,3 +8,6 @@ class ConversationSession:
     chat_id: int
     reply_to_message_id: Optional[int] = None
     is_forwarded: bool = False
+    # Explicit dialog branch to load as context (db message ids), bypassing
+    # last-message lookup and expiration. Used by scheduled task execution.
+    context_message_ids: Optional[List[int]] = None

--- a/app/storage/db.py
+++ b/app/storage/db.py
@@ -383,13 +383,13 @@ class DB:
 
     async def create_scheduled_task(self, chat_id: int, user_id: int, title: str, prompt: str,
                                     schedule_type: str, run_at, cron_expression: str,
-                                    next_execution) -> dict:
+                                    next_execution, context_message_ids: Optional[List[int]] = None) -> dict:
         sql = '''INSERT INTO chatgpttg.scheduled_task
-        (chat_id, user_id, title, prompt, schedule_type, run_at, cron_expression, next_execution)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING *'''
+        (chat_id, user_id, title, prompt, schedule_type, run_at, cron_expression, next_execution, context_message_ids)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING *'''
         record = await self.connection_pool.fetchrow(
             sql, chat_id, user_id, title, prompt, schedule_type,
-            run_at, cron_expression, next_execution
+            run_at, cron_expression, next_execution, context_message_ids or []
         )
         return dict(record)
 

--- a/migrations/sql/0017_scheduled_task_context.sql
+++ b/migrations/sql/0017_scheduled_task_context.sql
@@ -1,0 +1,2 @@
+ALTER TABLE chatgpttg.scheduled_task
+    ADD COLUMN IF NOT EXISTS context_message_ids BIGINT[] NOT NULL DEFAULT '{}';

--- a/settings.py
+++ b/settings.py
@@ -96,6 +96,7 @@ AGENT_BG_TASK_TIMEOUT = 300
 AGENT_PLAN_REMINDER_INTERVAL = 5
 MCP_TOOL_CALL_TIMEOUT = 300  # seconds, timeout for individual MCP tool calls
 SCHEDULER_POLL_INTERVAL = 30  # seconds between scheduler checks
+USER_TIMEZONE = 'UTC'  # IANA timezone users are assumed to be in (e.g. 'Europe/Moscow'); used for scheduled task times
 
 # MCP servers available only in agent mode (in addition to MCP_SERVERS)
 MCP_SERVERS_AGENT: list[MCPServerConfig] = [

--- a/settings_local.py.example
+++ b/settings_local.py.example
@@ -46,6 +46,11 @@ TELEGRAM_BOT_TOKEN = ''
 # === Image proxy ===
 # IMAGE_PROXY_URL = 'http://your-server-ip'
 
+# === Scheduled tasks timezone ===
+# IANA timezone your users are in; "tomorrow at 10am" and cron expressions
+# are interpreted in this zone (default is UTC).
+# USER_TIMEZONE = 'Europe/Moscow'
+
 # === MCP servers ===
 # from settings import MCPServerConfig
 # MCP_SERVERS = [

--- a/tests/e2e/test_scheduled_tasks.py
+++ b/tests/e2e/test_scheduled_tasks.py
@@ -227,6 +227,126 @@ class TestScheduleTaskTool:
         assert any('Error' in str(m.get('content', '')) for m in tool_results)
 
 
+class TestScheduledTaskContext:
+
+    async def test_schedule_task_stores_context_snapshot(self, bot_app):
+        """ScheduleTask stores the dialog branch it was created in, trimmed of the tool call itself."""
+        telegram_bot, dp, mock_bot = bot_app
+        user_id = 80006
+
+        await _create_agent_user(telegram_bot, dp, user_id)
+
+        mock_llm = MockLLMClient()
+        mock_llm.add_response(
+            content=None,
+            tool_calls=[{
+                'id': 'call_ctx1',
+                'function': {
+                    'name': 'ScheduleTask',
+                    'arguments': json.dumps({
+                        'title': 'Context Test',
+                        'prompt': 'Do the thing we discussed',
+                        'schedule_type': 'once',
+                        'when': 'in 2 hours',
+                    }),
+                },
+            }],
+        )
+        mock_llm.add_response(content="Scheduled with context!")
+        LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm
+
+        update = make_text_message('Schedule the thing we discussed', user_id=user_id)
+        await dp.process_update(update)
+        await asyncio.sleep(0.3)
+
+        tasks = await telegram_bot.db.get_scheduled_tasks(user_id)
+        assert len(tasks) == 1
+        context_ids = tasks[0]['context_message_ids']
+        assert context_ids, "context snapshot must be stored on the task"
+
+        # Snapshot holds the conversation branch: Hi / Hello! / the scheduling request,
+        # with the trailing ScheduleTask tool-call message trimmed off
+        messages = await telegram_bot.db.get_messages_by_ids(context_ids)
+        assert len(messages) == 3
+        assert messages[-1].message.role == 'user'
+        assert 'Schedule the thing we discussed' in str(messages[-1].message.content)
+        assert not messages[-1].message.tool_calls
+
+    async def test_scheduled_task_fires_with_creation_context(self, bot_app):
+        """When a task fires, the LLM sees the conversation the task was created in,
+        and the result is persisted into that dialog branch."""
+        telegram_bot, dp, mock_bot = bot_app
+        spy = BotSpy(mock_bot)
+        user_id = 80007
+
+        user = await _create_agent_user(telegram_bot, dp, user_id)
+
+        # Conversation with a distinctive fact, then scheduling
+        mock_llm = MockLLMClient()
+        mock_llm.add_response(content="Noted, turquoise it is.")
+        LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm
+        update = make_text_message('My favorite color is turquoise', user_id=user_id)
+        await dp.process_update(update)
+        await asyncio.sleep(0.2)
+
+        mock_llm = MockLLMClient()
+        mock_llm.add_response(
+            content=None,
+            tool_calls=[{
+                'id': 'call_ctx2',
+                'function': {
+                    'name': 'ScheduleTask',
+                    'arguments': json.dumps({
+                        'title': 'Color Reminder',
+                        'prompt': 'Remind me about my favorite color',
+                        'schedule_type': 'once',
+                        'when': 'in 2 hours',
+                    }),
+                },
+            }],
+        )
+        mock_llm.add_response(content="Will remind you!")
+        LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm
+
+        update = make_text_message('Remind me about it later', user_id=user_id)
+        await dp.process_update(update)
+        await asyncio.sleep(0.3)
+
+        tasks = await telegram_bot.db.get_scheduled_tasks(user_id)
+        assert len(tasks) == 1
+        context_ids = tasks[0]['context_message_ids']
+        assert context_ids
+
+        # Fire the task directly (bypassing the poll loop)
+        fire_llm = MockLLMClient()
+        fire_llm.add_response(content="Your favorite color is turquoise!")
+        LLMClientFactory._model_clients['gpt-3.5-turbo'] = fire_llm
+
+        await telegram_bot.scheduler_service._execute_task(tasks[0])
+        await asyncio.sleep(0.2)
+
+        # The LLM saw the creation-time conversation
+        assert len(fire_llm.calls) == 1
+        llm_messages_str = str(fire_llm.calls[0]['messages'])
+        assert 'turquoise' in llm_messages_str
+        assert 'Remind me about my favorite color' in llm_messages_str
+
+        # Notification and result were sent to the chat
+        spy.assert_sent_text_contains("⏰ Scheduled task: Color Reminder")
+        spy.assert_sent_text_contains("Your favorite color is turquoise!")
+
+        # The result is persisted as a continuation of the creation branch,
+        # so the user can reply to it and keep the conversation going
+        last_message = await telegram_bot.db.get_last_message(user.id, user_id)
+        assert 'Your favorite color is turquoise!' in str(last_message.message.content)
+        assert last_message.tg_message_id > 0
+        assert set(context_ids).issubset(set(last_message.previous_message_ids))
+
+        # One-time task got disabled after firing
+        tasks_after = await telegram_bot.db.get_scheduled_tasks(user_id, enabled_only=True)
+        assert len(tasks_after) == 0
+
+
 class TestSchedulerServiceDB:
 
     async def test_get_due_tasks(self, db):
@@ -286,6 +406,26 @@ class TestSchedulerServiceDB:
         assert len(tasks) == 1
         assert tasks[0]['last_execution'] is not None
         assert tasks[0]['next_execution'] > now
+
+    async def test_create_task_with_context_message_ids(self, db):
+        """context_message_ids round-trips through the DB; omitted defaults to empty."""
+        user = await db.create_user(99805, settings.USER_ROLE_DEFAULT)
+
+        future_time = datetime.now(timezone.utc) + timedelta(hours=1)
+        record = await db.create_scheduled_task(
+            chat_id=99805, user_id=user.id, title='With Context',
+            prompt='Something', schedule_type='once',
+            run_at=future_time, cron_expression=None, next_execution=future_time,
+            context_message_ids=[101, 102, 103],
+        )
+        assert record['context_message_ids'] == [101, 102, 103]
+
+        record_no_ctx = await db.create_scheduled_task(
+            chat_id=99805, user_id=user.id, title='No Context',
+            prompt='Something', schedule_type='once',
+            run_at=future_time, cron_expression=None, next_execution=future_time,
+        )
+        assert record_no_ctx['context_message_ids'] == []
 
     async def test_get_user_by_id(self, db):
         """get_user_by_id returns user by primary key."""

--- a/tests/e2e/test_scheduled_tasks.py
+++ b/tests/e2e/test_scheduled_tasks.py
@@ -330,6 +330,8 @@ class TestScheduledTaskContext:
         llm_messages_str = str(fire_llm.calls[0]['messages'])
         assert 'turquoise' in llm_messages_str
         assert 'Remind me about my favorite color' in llm_messages_str
+        # The trigger is explicitly marked as an execution, not a scheduling request
+        assert '<scheduled_task_execution>' in llm_messages_str
 
         # Notification and result were sent to the chat
         spy.assert_sent_text_contains("⏰ Scheduled task: Color Reminder")

--- a/tests/e2e/test_scheduled_tasks.py
+++ b/tests/e2e/test_scheduled_tasks.py
@@ -2,6 +2,8 @@ import asyncio
 import json
 from datetime import datetime, timezone, timedelta
 
+import pytz
+
 import settings
 from app.openai_helpers.llm_client_factory import LLMClientFactory
 from tests.helpers.mock_llm_client import MockLLMClient
@@ -225,6 +227,100 @@ class TestScheduleTaskTool:
         assert len(mock_llm.calls) >= 2
         tool_results = [m for m in mock_llm.calls[1]['messages'] if m.get('role') == 'tool']
         assert any('Error' in str(m.get('content', '')) for m in tool_results)
+
+
+class TestScheduledTaskTimezone:
+
+    async def test_once_task_uses_configured_timezone(self, bot_app):
+        """'tomorrow at 10:00' with USER_TIMEZONE=Europe/Moscow schedules 10:00 MSK (07:00 UTC)."""
+        telegram_bot, dp, mock_bot = bot_app
+        user_id = 80008
+        moscow = pytz.timezone('Europe/Moscow')
+
+        await _create_agent_user(telegram_bot, dp, user_id)
+
+        original_tz = settings.USER_TIMEZONE
+        settings.USER_TIMEZONE = 'Europe/Moscow'
+        try:
+            mock_llm = MockLLMClient()
+            mock_llm.add_response(
+                content=None,
+                tool_calls=[{
+                    'id': 'call_tz1',
+                    'function': {
+                        'name': 'ScheduleTask',
+                        'arguments': json.dumps({
+                            'title': 'Morning Task',
+                            'prompt': 'Do the morning thing',
+                            'schedule_type': 'once',
+                            'when': 'tomorrow at 10:00',
+                        }),
+                    },
+                }],
+            )
+            mock_llm.add_response(content="Scheduled!")
+            LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm
+
+            update = make_text_message('Schedule for tomorrow morning', user_id=user_id)
+            await dp.process_update(update)
+            await asyncio.sleep(0.3)
+
+            tasks = await telegram_bot.db.get_scheduled_tasks(user_id)
+            assert len(tasks) == 1
+            next_execution = tasks[0]['next_execution']
+
+            local = next_execution.astimezone(moscow)
+            assert (local.hour, local.minute) == (10, 0)
+            assert local.date() == (datetime.now(moscow) + timedelta(days=1)).date()
+            # Moscow is UTC+3, so the stored UTC instant is 07:00
+            assert next_execution.astimezone(timezone.utc).hour == 7
+
+            # Tool result reports the time in the configured zone
+            tool_results = [m for m in mock_llm.calls[1]['messages'] if m.get('role') == 'tool']
+            assert any('(Europe/Moscow)' in str(m.get('content', '')) for m in tool_results)
+        finally:
+            settings.USER_TIMEZONE = original_tz
+
+    async def test_recurring_task_cron_in_configured_timezone(self, bot_app):
+        """Cron '0 10 * * *' with USER_TIMEZONE=Europe/Moscow means 10:00 MSK, not UTC."""
+        telegram_bot, dp, mock_bot = bot_app
+        user_id = 80009
+        moscow = pytz.timezone('Europe/Moscow')
+
+        await _create_agent_user(telegram_bot, dp, user_id)
+
+        original_tz = settings.USER_TIMEZONE
+        settings.USER_TIMEZONE = 'Europe/Moscow'
+        try:
+            mock_llm = MockLLMClient()
+            mock_llm.add_response(
+                content=None,
+                tool_calls=[{
+                    'id': 'call_tz2',
+                    'function': {
+                        'name': 'ScheduleTask',
+                        'arguments': json.dumps({
+                            'title': 'Daily Local',
+                            'prompt': 'Daily thing',
+                            'schedule_type': 'recurring',
+                            'cron_expression': '0 10 * * *',
+                        }),
+                    },
+                }],
+            )
+            mock_llm.add_response(content="Scheduled daily!")
+            LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm
+
+            update = make_text_message('Schedule daily task', user_id=user_id)
+            await dp.process_update(update)
+            await asyncio.sleep(0.3)
+
+            tasks = await telegram_bot.db.get_scheduled_tasks(user_id)
+            assert len(tasks) == 1
+            local = tasks[0]['next_execution'].astimezone(moscow)
+            assert (local.hour, local.minute) == (10, 0)
+        finally:
+            settings.USER_TIMEZONE = original_tz
 
 
 class TestScheduledTaskContext:


### PR DESCRIPTION
Scheduled tasks used to fire with whatever context happened to be live in the chat (usually none, since the originating conversation expires after an hour). Now ScheduleTask snapshots the dialog branch it was created in, and the scheduler loads exactly that branch when the task fires. The task result is also persisted into the branch, so replying to it continues the conversation with full context.

- migration 0017: context_message_ids column on scheduled_task
- ScheduleTask stores the branch snapshot, trimming the trailing unfinished tool exchange so the stored context is valid on its own
- ConversationSession/DialogManager: explicit-branch loading path that bypasses last-message lookup and expiration
- SchedulerService passes the snapshot and saves the final response with the real telegram message id (tasks created before the migration fall back to the old behavior)