### PR TITLE
Transcribe Telegram video notes (round videos) via Whisper

### DIFF
--- a/app/bot/batched_input_handler.py
+++ b/app/bot/batched_input_handler.py
@@ -90,8 +90,8 @@ class BatchedInputHandler:
         Batch is prompt if one message in batch is prompt
         """
         for message in messages_batch:
-            if not message_is_forward(message) and not message.voice and not message.document:
-                # not voice and not forward and not document - it's a prompt no matter what settings
+            if not message_is_forward(message) and not message.voice and not message.video_note and not message.document:
+                # not voice and not video_note and not forward and not document - it's a prompt no matter what settings
                 return True
             elif message_is_forward(message):
                 # if it's a forward, we need to check forward_as_prompt setting
@@ -101,8 +101,8 @@ class BatchedInputHandler:
                 else:
                     # forward and not forward_as_prompt - it's a context, no matter what content it has
                     continue
-            elif message.voice and user.voice_as_prompt:
-                # voice and voice_as_prompt - it's a prompt
+            elif (message.voice or message.video_note) and user.voice_as_prompt:
+                # voice or video note (round video) and voice_as_prompt - it's a prompt
                 return True
         # no prompt messages in batch
         return False
@@ -120,6 +120,8 @@ class BatchedInputHandler:
                 if message.audio:
                     await self.handle_voice(message, user, user_input)
                 elif message.voice:
+                    await self.handle_voice(message, user, user_input)
+                elif message.video_note:
                     await self.handle_voice(message, user, user_input)
                 elif message.document:
                     await self.handle_document(message, user, user_input)
@@ -240,15 +242,18 @@ class BatchedInputHandler:
 
     async def handle_voice(self, message: types.Message, user: User, user_input: UserInput):
         """
-        Handles voice message or audio file with voice. Downloads voice file, converts it to mp3, sends it to whisper,
-        sends response to user, adds response to context.
+        Handles voice message, audio file, or video note (round video). Downloads the file, extracts audio and
+        converts it to mp3 (ffmpeg handles video notes too), sends it to whisper, sends response to user,
+        adds response to context.
         """
         if message.voice:
             audio_file = message.voice
         elif message.audio:
             audio_file = message.audio
+        elif message.video_note:
+            audio_file = message.video_note
         else:
-            raise ValueError('Message has no voice or audio')
+            raise ValueError('Message has no voice, audio or video note')
 
         file_id = audio_file.file_id
         file = await self.bot.get_file(file_id)

--- a/app/bot/telegram_bot.py
+++ b/app/bot/telegram_bot.py
@@ -67,7 +67,7 @@ class TelegramBot:
         self.batched_handler = BatchedInputHandler(self.bot, self.db, self.cancellation_manager)
         self.dispatcher.register_message_handler(self.batched_handler.handle, content_types=[
             types.ContentType.TEXT, types.ContentType.VIDEO, types.ContentType.PHOTO, types.ContentType.VOICE,
-            types.ContentType.DOCUMENT, types.ContentType.AUDIO,
+            types.ContentType.DOCUMENT, types.ContentType.AUDIO, types.ContentType.VIDEO_NOTE,
         ])
 
         # all commands are added to global scope by default, except for admin commands

--- a/tests/e2e/test_video_note.py
+++ b/tests/e2e/test_video_note.py
@@ -1,0 +1,113 @@
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from aiogram import types
+
+from app.openai_helpers.llm_client_factory import LLMClientFactory
+from tests.helpers.mock_llm_client import MockLLMClient
+from tests.helpers.telegram_factory import make_text_message, make_video_note_message
+from tests.helpers.bot_spy import BotSpy
+
+
+class _FakeAudio:
+    """Minimal stand-in for pydub.AudioSegment (ms length + export)."""
+    def __len__(self):
+        return 3000  # 3 seconds
+
+    def export(self, *args, **kwargs):
+        return None
+
+
+def _mock_video_note_download(mock_bot):
+    mock_bot.get_file = AsyncMock(return_value=types.File(
+        file_id='test-video-note-id',
+        file_unique_id='unique-test-video-note-id',
+        file_size=2048,
+        file_path='video_notes/test-note',
+    ))
+
+    async def fake_download(file_path, destination=None, **kwargs):
+        with open(destination, 'wb') as f:
+            f.write(b'fake-mp4-bytes')
+
+    mock_bot.download_file = AsyncMock(side_effect=fake_download)
+
+
+async def _create_user(telegram_bot, dp, user_id, voice_as_prompt):
+    mock_llm = MockLLMClient()
+    mock_llm.add_response("Hello!")
+    LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm
+
+    update = make_text_message('Hi', user_id=user_id)
+    await dp.process_update(update)
+    await asyncio.sleep(0.1)
+
+    user = await telegram_bot.db.get_user(user_id)
+    user.voice_as_prompt = voice_as_prompt
+    await telegram_bot.db.update_user(user)
+    return user
+
+
+class TestVideoNoteTranscription:
+
+    async def test_video_note_as_prompt_triggers_llm(self, bot_app):
+        """With voice_as_prompt on, a video note is transcribed and answered by the LLM."""
+        telegram_bot, dp, mock_bot = bot_app
+        spy = BotSpy(mock_bot)
+        user_id = 90001
+
+        await _create_user(telegram_bot, dp, user_id, voice_as_prompt=True)
+        _mock_video_note_download(mock_bot)
+
+        mock_llm = MockLLMClient()
+        mock_llm.add_response("Answering your circle video.")
+        LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm
+
+        with patch('app.bot.batched_input_handler.AudioSegment') as mock_audioseg, \
+                patch('app.bot.batched_input_handler.get_audio_speech_to_text',
+                      AsyncMock(return_value='transcribed circle text')):
+            mock_audioseg.from_file.return_value = _FakeAudio()
+            update = make_video_note_message(user_id=user_id)
+            await dp.process_update(update)
+            await asyncio.sleep(0.3)
+
+        # transcription echoed back to the user
+        spy.assert_sent_text_contains('transcribed circle text')
+        # LLM was called and its answer delivered
+        spy.assert_sent_text_contains('Answering your circle video.')
+        assert len(mock_llm.calls) == 1
+        all_contents = [str(m.get('content', '')) for m in mock_llm.calls[0]['messages']]
+        assert any('transcribed circle text' in c for c in all_contents)
+
+        # whisper usage recorded (table is truncated between tests)
+        usage = await telegram_bot.db.connection_pool.fetchval(
+            'SELECT count(*) FROM chatgpttg.whisper_usage'
+        )
+        assert usage == 1
+
+    async def test_video_note_as_context_only(self, bot_app):
+        """With voice_as_prompt off, a video note is transcribed into context without calling the LLM."""
+        telegram_bot, dp, mock_bot = bot_app
+        spy = BotSpy(mock_bot)
+        user_id = 90002
+
+        await _create_user(telegram_bot, dp, user_id, voice_as_prompt=False)
+        _mock_video_note_download(mock_bot)
+
+        mock_llm = MockLLMClient()
+        # No response queued: if the LLM were called, it would raise
+        LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm
+
+        with patch('app.bot.batched_input_handler.AudioSegment') as mock_audioseg, \
+                patch('app.bot.batched_input_handler.get_audio_speech_to_text',
+                      AsyncMock(return_value='context circle text')):
+            mock_audioseg.from_file.return_value = _FakeAudio()
+            update = make_video_note_message(user_id=user_id)
+            await dp.process_update(update)
+            await asyncio.sleep(0.3)
+
+        # transcription still echoed to the user
+        spy.assert_sent_text_contains('context circle text')
+        # LLM was NOT called
+        assert len(mock_llm.calls) == 0

--- a/tests/helpers/telegram_factory.py
+++ b/tests/helpers/telegram_factory.py
@@ -92,6 +92,33 @@ def make_document_message(file_name, file_id='test-doc-file-id', file_size=100,
     return types.Update(**update_dict)
 
 
+def make_video_note_message(file_id='test-video-note-id', file_size=2048, duration=5,
+                            length=240, user_id=12345, chat_id=None):
+    if chat_id is None:
+        chat_id = user_id
+
+    message_id = _next_message_id()
+    message_dict = {
+        'message_id': message_id,
+        'from': _make_user_dict(user_id),
+        'chat': _make_chat_dict(chat_id),
+        'date': int(time.time()),
+        'video_note': {
+            'file_id': file_id,
+            'file_unique_id': f'unique-{file_id}',
+            'length': length,
+            'duration': duration,
+            'file_size': file_size,
+        },
+    }
+
+    update_dict = {
+        'update_id': _next_update_id(),
+        'message': message_dict,
+    }
+    return types.Update(**update_dict)
+
+
 def make_command_message(command, user_id=12345, chat_id=None, **kwargs):
     return make_text_message(f'/{command}', user_id=user_id, chat_id=chat_id, **kwargs)
 


### PR DESCRIPTION
Video notes (message.video_note) now go through the same Whisper pipeline as voice messages — ffmpeg extracts the audio track from the mp4. They obey the existing voice_as_prompt setting: register the VIDEO_NOTE content type, dispatch video notes to handle_voice, and treat them like voice in batch_is_prompt (previously they slipped through as unconditional prompts).