### PR TITLE
Fix background task timeouts in agent mode

### DIFF
--- a/app/functions/agent_tools.py
+++ b/app/functions/agent_tools.py
@@ -1,6 +1,7 @@
+import contextvars
 import logging
 from dataclasses import dataclass
-from typing import Optional, List, ClassVar
+from typing import Optional, List
 
 import pydantic
 import pytz
@@ -31,13 +32,20 @@ class AgentToolContext:
     sub_agent_runner: object  # callable: async def(prompt) -> str
 
 
+# Per-turn agent context. A ContextVar (not a class attribute) so that concurrent
+# turns (e.g. a scheduled task firing while a user turn runs) don't clobber each
+# other: tasks spawned within a turn inherit a copy of the turn's context.
+agent_context_var: contextvars.ContextVar[Optional[AgentToolContext]] = contextvars.ContextVar(
+    'agent_context', default=None,
+)
+
+
 class AgentFunction(OpenAIFunction):
-    """Base class for agent tools. Accesses per-turn context via _agent_context class var."""
-    _agent_context: ClassVar[Optional[AgentToolContext]] = None
+    """Base class for agent tools. Accesses per-turn context via agent_context_var."""
 
     @property
     def agent_ctx(self) -> AgentToolContext:
-        ctx = self.__class__._agent_context
+        ctx = agent_context_var.get()
         if ctx is None:
             raise RuntimeError("AgentToolContext not set")
         return ctx

--- a/app/runtime/agent_runtime.py
+++ b/app/runtime/agent_runtime.py
@@ -1,13 +1,15 @@
 from typing import Callable, AsyncGenerator, Optional, List
 
+import asyncio
 import logging
+import time
 
 import settings
 from app.bot.chatgpt_manager import ChatGptManager
 from app.context.context_manager import ContextManager, build_context_manager
 from app.context.dialog_manager import DialogUtils
 from app.functions.agent_tools import (
-    AgentFunction, AgentToolContext,
+    AgentToolContext, agent_context_var,
     AGENT_TOOLS_CORE, PLAN_TOOLS_NO_PLAN, PLAN_TOOLS_WITH_PLAN,
     SUB_AGENT_EXCLUDED_TOOLS,
 )
@@ -125,17 +127,18 @@ class AgentRuntime:
 
         # Build sub-agent runner
         async def sub_agent_runner(prompt: str) -> str:
+            deadline = time.monotonic() + settings.AGENT_BG_TASK_TIMEOUT
             return await self._run_sub_agent(
-                prompt, llm_model, function_storage, context_manager,
+                prompt, llm_model, function_storage, context_manager, deadline,
             )
 
-        # Set agent context on tool classes
+        # Set agent context for tools (ContextVar: isolated per turn, inherited by spawned tasks)
         agent_ctx = AgentToolContext(
             bg_manager=bg_manager,
             plan_manager=plan_manager,
             sub_agent_runner=sub_agent_runner,
         )
-        AgentFunction._agent_context = agent_ctx
+        ctx_token = agent_context_var.set(agent_ctx)
 
         try:
             async for event in self._agent_loop(
@@ -145,7 +148,7 @@ class AgentRuntime:
                 yield event
         finally:
             await bg_manager.cancel_all()
-            AgentFunction._agent_context = None
+            agent_context_var.reset(ctx_token)
 
     async def _agent_loop(
         self, chat_gpt, chat_gpt_manager: ChatGptManager, context_manager: ContextManager,
@@ -239,8 +242,7 @@ class AgentRuntime:
                 new_notifs = bg_manager.drain_notifications()
                 if new_notifs:
                     # Put them back for the next iteration to inject
-                    for n in new_notifs:
-                        await bg_manager._notification_queue.put(n)
+                    bg_manager.requeue(new_notifs)
                     iteration += 1
                     continue
                 break
@@ -337,13 +339,19 @@ class AgentRuntime:
 
     async def _run_sub_agent(
         self, prompt: str, llm_model, parent_function_storage: FunctionStorage,
-        parent_context_manager: ContextManager,
+        parent_context_manager: ContextManager, deadline: float,
     ) -> str:
-        """Run a sub-agent loop with limited tools and plan context.
+        """Run a sub-agent loop with limited tools, plan context and parent conversation context.
 
-        Uses the same _agent_context as the parent. Excluded tools prevent
+        Uses the same agent context (ContextVar) as the parent. Excluded tools prevent
         recursive spawning and plan creation/deletion by sub-agents.
+
+        `deadline` is a time.monotonic() timestamp. The sub-agent stops itself when the
+        deadline approaches and returns whatever progress it has made, instead of being
+        cancelled from outside and losing everything.
         """
+        started_at = time.monotonic()
+
         # Build a function_storage for the sub-agent: exclude management tools
         sub_function_storage = FunctionStorage()
         for func_name, func_data in parent_function_storage.functions.items():
@@ -351,11 +359,12 @@ class AgentRuntime:
                 sub_function_storage.functions[func_name] = func_data
 
         # Build system prompt with optional plan context
-        sub_system_prompt = "You are a sub-agent working on a specific task. Complete it and return your result.\n\n"
-        plan_text = await AgentFunction._agent_context.plan_manager.get_plan()
-        if plan_text and plan_text != "No active plan.":
-            sub_system_prompt += f"Current plan:\n{plan_text}\n\n"
-        sub_system_prompt += f"Task: {prompt}"
+        sub_system_prompt = "You are a sub-agent working on a specific task. Complete it and return your result."
+        agent_ctx = agent_context_var.get()
+        if agent_ctx is not None:
+            plan_text = await agent_ctx.plan_manager.get_plan()
+            if plan_text and plan_text != "No active plan.":
+                sub_system_prompt += f"\n\nCurrent plan:\n{plan_text}"
 
         langfuse_metadata = build_langfuse_metadata(self.user)
         if llm_model.ANTHROPIC_CLAUDE_35_SONNET == self.user.current_model:
@@ -363,16 +372,74 @@ class AgentRuntime:
         else:
             sub_chatgpt = ChatGPT(llm_model, sub_system_prompt, sub_function_storage, langfuse_metadata=langfuse_metadata)
 
-        # No context swapping — sub-agent shares parent's _agent_context.
-        # SpawnTask is not in sub_function_storage, so nesting is impossible.
-        messages = [DialogUtils.prepare_user_message(prompt)]
-        for _ in range(settings.AGENT_SUB_AGENT_MAX_ITERATIONS):
-            dialog_message, _ = await sub_chatgpt.send_messages(messages)
+        # Snapshot the parent conversation so the sub-agent starts with full context
+        # instead of cold. Trailing messages of an unfinished tool exchange (including
+        # the SpawnTask call itself) are trimmed to keep the context valid.
+        context_messages = list(await parent_context_manager.get_context_messages())
+        while context_messages and (
+            context_messages[-1].role in ('tool', 'function')
+            or context_messages[-1].tool_calls
+            or context_messages[-1].function_call
+        ):
+            context_messages.pop()
+        messages = context_messages + [DialogUtils.prepare_user_message(prompt)]
+
+        executed_tools: List[str] = []
+        last_assistant_text = ''
+
+        def partial_result(reason: str) -> str:
+            lines = [f"Sub-agent stopped early: {reason}. Progress so far:"]
+            if executed_tools:
+                lines.append("Tool calls executed:")
+                lines.extend(f"- {entry}" for entry in executed_tools)
+            if last_assistant_text:
+                lines.append(f"Last assistant output:\n{last_assistant_text}")
+            if not executed_tools and not last_assistant_text:
+                lines.append("(no progress)")
+            return "\n".join(lines)
+
+        async def run_tool(function_name: str, arguments: str, tool_call_id) -> str:
+            tool_started = time.monotonic()
+            try:
+                function_class = sub_function_storage.get_function_class(function_name)
+                function = function_class(
+                    self.user, self.db, parent_context_manager,
+                    self.side_effects, tool_call_id
+                )
+                result = await function.run_str_args(arguments)
+            except Exception as e:
+                result = f"Error: {e}"
+            result = result if result is not None else "(no output)"
+            logger.debug(f"[sub-agent] tool {function_name} finished in {time.monotonic() - tool_started:.1f}s")
+            executed_tools.append(f"{function_name}: {result[:200]}")
+            return result
+
+        for iteration in range(settings.AGENT_SUB_AGENT_MAX_ITERATIONS):
+            remaining = deadline - time.monotonic()
+            if remaining < 30:
+                logger.warning(f"[sub-agent] deadline reached at iteration {iteration}, returning partial result")
+                return partial_result(f"deadline reached after {time.monotonic() - started_at:.0f}s")
+
+            llm_timeout = min(settings.AGENT_SUB_AGENT_LLM_TIMEOUT, remaining)
+            llm_started = time.monotonic()
+            try:
+                dialog_message, _ = await asyncio.wait_for(
+                    sub_chatgpt.send_messages(messages), timeout=llm_timeout,
+                )
+            except asyncio.TimeoutError:
+                logger.warning(f"[sub-agent] LLM call timed out after {llm_timeout:.0f}s at iteration {iteration}")
+                return partial_result(f"LLM call timed out after {llm_timeout:.0f}s")
+            logger.debug(f"[sub-agent] iteration {iteration}: LLM call took {time.monotonic() - llm_started:.1f}s")
             dialog_message = dialog_message.strip_thinking()
+
+            text_content = dialog_message.get_text_content()
+            if text_content:
+                last_assistant_text = text_content
 
             # If no tool calls, we're done
             if not dialog_message.tool_calls and not dialog_message.function_call:
-                return dialog_message.get_text_content() or "(empty response)"
+                logger.info(f"[sub-agent] completed in {time.monotonic() - started_at:.1f}s, {iteration + 1} iteration(s)")
+                return text_content or "(empty response)"
 
             # Handle tool calls
             messages.append(dialog_message)
@@ -381,30 +448,13 @@ class AgentRuntime:
                 for tool_call in dialog_message.tool_calls:
                     if tool_call.type != 'function':
                         continue
-                    try:
-                        function_class = sub_function_storage.get_function_class(tool_call.function.name)
-                        function = function_class(
-                            self.user, self.db, parent_context_manager,
-                            self.side_effects, tool_call.id
-                        )
-                        result = await function.run_str_args(tool_call.function.arguments)
-                    except Exception as e:
-                        result = f"Error: {e}"
-                    result = result if result is not None else "(no output)"
+                    result = await run_tool(tool_call.function.name, tool_call.function.arguments, tool_call.id)
                     messages.append(DialogUtils.prepare_tool_call_response(tool_call.id, result))
 
             elif dialog_message.function_call:
                 fc = dialog_message.function_call
-                try:
-                    function_class = sub_function_storage.get_function_class(fc.name)
-                    function = function_class(
-                        self.user, self.db, parent_context_manager,
-                        self.side_effects, None
-                    )
-                    result = await function.run_str_args(fc.arguments)
-                except Exception as e:
-                    result = f"Error: {e}"
-                result = result if result is not None else "(no output)"
+                result = await run_tool(fc.name, fc.arguments, None)
                 messages.append(DialogUtils.prepare_function_response(fc.name, result))
 
-        return "Sub-agent reached iteration limit without completing"
+        logger.warning(f"[sub-agent] iteration limit reached after {time.monotonic() - started_at:.1f}s")
+        return partial_result("iteration limit reached")

--- a/app/runtime/background_task_manager.py
+++ b/app/runtime/background_task_manager.py
@@ -1,7 +1,16 @@
 import asyncio
+import logging
+import time
 import uuid
 from dataclasses import dataclass, field
 from typing import Optional, Callable, Coroutine, Dict, List
+
+logger = logging.getLogger(__name__)
+
+# Extra slack on top of the configured timeout: the sub-agent is expected to stop
+# itself at its own deadline and return a partial result; the wait_for here is only
+# a backstop against hangs outside the sub-agent's control.
+BACKSTOP_GRACE_SECONDS = 60
 
 
 @dataclass
@@ -32,10 +41,12 @@ class BackgroundTaskManager:
         task_id = str(uuid.uuid4())[:8]
         info = TaskInfo(task_id=task_id, description=description, status="running")
         self.tasks[task_id] = info
+        logger.info(f"[bg:{task_id}] spawned: {description[:120]}")
+        started_at = time.monotonic()
 
         async def _wrapper():
             try:
-                result = await asyncio.wait_for(coro, timeout=self._timeout)
+                result = await asyncio.wait_for(coro, timeout=self._timeout + BACKSTOP_GRACE_SECONDS)
                 output = str(result)[:50000] if result else "(no output)"
                 info.status = "completed"
                 info.result = output
@@ -46,11 +57,16 @@ class BackgroundTaskManager:
             except asyncio.CancelledError:
                 info.status = "cancelled"
                 info.result = "Task cancelled"
+                logger.info(f"[bg:{task_id}] cancelled after {time.monotonic() - started_at:.1f}s")
                 return  # Don't notify on cancellation
             except Exception as e:
                 info.status = "error"
                 info.result = f"Error: {e}"
                 output = info.result
+
+            elapsed = time.monotonic() - started_at
+            log = logger.info if info.status == "completed" else logger.warning
+            log(f"[bg:{task_id}] {info.status} after {elapsed:.1f}s, result {len(output or '')} chars")
 
             await self._notification_queue.put(TaskNotification(
                 task_id=task_id,
@@ -89,6 +105,11 @@ class BackgroundTaskManager:
             except asyncio.QueueEmpty:
                 break
         return notifications
+
+    def requeue(self, notifications: List[TaskNotification]) -> None:
+        """Put notifications back on the queue (e.g. to deliver them next iteration)."""
+        for notif in notifications:
+            self._notification_queue.put_nowait(notif)
 
     def has_pending(self) -> bool:
         """Check if any tasks are still running."""

--- a/settings.py
+++ b/settings.py
@@ -92,7 +92,8 @@ updating all affected plan steps. Valid statuses: pending, in_progress, complete
 ENABLE_AGENT_RUNTIME = True
 AGENT_MAX_ITERATIONS = 30
 AGENT_SUB_AGENT_MAX_ITERATIONS = 10
-AGENT_BG_TASK_TIMEOUT = 300
+AGENT_BG_TASK_TIMEOUT = 900
+AGENT_SUB_AGENT_LLM_TIMEOUT = 120  # seconds, timeout for a single sub-agent LLM call
 AGENT_PLAN_REMINDER_INTERVAL = 5
 MCP_TOOL_CALL_TIMEOUT = 300  # seconds, timeout for individual MCP tool calls
 SCHEDULER_POLL_INTERVAL = 30  # seconds between scheduler checks

--- a/tests/e2e/test_agent_runtime.py
+++ b/tests/e2e/test_agent_runtime.py
@@ -449,6 +449,152 @@ class TestAgentRuntime:
         for tr in tool_results:
             assert 'started' in tr.get('content', ''), f"Expected 'started' but got: {tr.get('content')}"
 
+    async def test_agent_mode_sub_agent_receives_conversation_context(self, bot_app):
+        """Sub-agent starts with the parent conversation context, not cold."""
+        telegram_bot, dp, mock_bot = bot_app
+        spy = BotSpy(mock_bot)
+        user_id = 70012
+
+        await _create_agent_user(telegram_bot, dp, user_id)
+
+        mock_llm = MockLLMClient()
+        mock_llm.add_response(
+            content=None,
+            tool_calls=[{
+                'id': 'call_ctx_spawn',
+                'function': {
+                    'name': 'SpawnTask',
+                    'arguments': json.dumps({
+                        'description': 'Subtask',
+                        'prompt': 'Do subtask X',
+                    }),
+                },
+            }],
+        )
+        mock_llm.add_response(content="Sub result")
+        # Sub-agent completes before the next main iteration, so its result is
+        # injected right away and the main agent finishes in one more call.
+        mock_llm.add_response(content="Task finished.")
+        LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm
+
+        update = make_text_message('Analyze the quarterly numbers', user_id=user_id)
+        await dp.process_update(update)
+        await asyncio.sleep(1.0)
+
+        spy.assert_sent_text_contains("Task finished.")
+
+        # Find the sub-agent's LLM call: its last user message is the spawn prompt
+        sub_agent_calls = [
+            c for c in mock_llm.calls
+            if any(m.get('role') == 'user' and m.get('content') == 'Do subtask X' for m in c['messages'])
+        ]
+        assert len(sub_agent_calls) >= 1, "Sub-agent LLM call not found"
+        sub_call = sub_agent_calls[0]
+        assert sub_call['messages'][0]['role'] == 'system'
+        assert 'You are a sub-agent' in sub_call['messages'][0]['content']
+        # Parent conversation must be present before the task prompt
+        assert any(
+            m.get('role') == 'user' and 'Analyze the quarterly numbers' in str(m.get('content', ''))
+            for m in sub_call['messages']
+        ), f"Parent context missing from sub-agent messages: {sub_call['messages']}"
+        # Task prompt is the last message
+        assert sub_call['messages'][-1]['content'] == 'Do subtask X'
+
+    async def test_agent_mode_sub_agent_llm_timeout_returns_partial(self, bot_app, monkeypatch):
+        """A stalled sub-agent LLM call yields a partial result, not a lost task."""
+        telegram_bot, dp, mock_bot = bot_app
+        spy = BotSpy(mock_bot)
+        user_id = 70013
+
+        await _create_agent_user(telegram_bot, dp, user_id)
+
+        monkeypatch.setattr(settings, 'AGENT_SUB_AGENT_LLM_TIMEOUT', 0.3)
+
+        mock_llm = MockLLMClient()
+        mock_llm.add_response(
+            content=None,
+            tool_calls=[{
+                'id': 'call_stall_spawn',
+                'function': {
+                    'name': 'SpawnTask',
+                    'arguments': json.dumps({
+                        'description': 'Stalled task',
+                        'prompt': 'Do the stalled thing',
+                    }),
+                },
+            }],
+        )
+        # Sub-agent's LLM call stalls beyond AGENT_SUB_AGENT_LLM_TIMEOUT
+        mock_llm.add_response(content="Too late", delay=2.0)
+        mock_llm.add_response(content="Waiting for the task.")
+        mock_llm.add_response(content="Handled the timeout.")
+        LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm
+
+        update = make_text_message('Run a stalled task', user_id=user_id)
+        await dp.process_update(update)
+        await asyncio.sleep(2.0)
+
+        spy.assert_sent_text_contains("Handled the timeout.")
+
+        # The main agent must have received a background result describing the partial state
+        bg_result_calls = [
+            c for c in mock_llm.calls
+            if any('<background-results>' in str(m.get('content', '')) for m in c['messages'])
+        ]
+        assert len(bg_result_calls) >= 1, "No <background-results> delivered to the main agent"
+        bg_content = "\n".join(
+            str(m.get('content', ''))
+            for c in bg_result_calls for m in c['messages']
+            if '<background-results>' in str(m.get('content', ''))
+        )
+        assert 'completed' in bg_content
+        assert 'Sub-agent stopped early' in bg_content
+        assert 'timed out' in bg_content
+
+    async def test_agent_mode_sub_agent_deadline_returns_partial(self, bot_app, monkeypatch):
+        """When the deadline is already tight, the sub-agent returns progress instead of timing out."""
+        telegram_bot, dp, mock_bot = bot_app
+        spy = BotSpy(mock_bot)
+        user_id = 70014
+
+        await _create_agent_user(telegram_bot, dp, user_id)
+
+        # Deadline budget below the 30s per-iteration reserve → immediate partial result
+        monkeypatch.setattr(settings, 'AGENT_BG_TASK_TIMEOUT', 5)
+
+        mock_llm = MockLLMClient()
+        mock_llm.add_response(
+            content=None,
+            tool_calls=[{
+                'id': 'call_dl_spawn',
+                'function': {
+                    'name': 'SpawnTask',
+                    'arguments': json.dumps({
+                        'description': 'Deadline task',
+                        'prompt': 'Do the deadline thing',
+                    }),
+                },
+            }],
+        )
+        # Sub-agent hits the deadline immediately (no LLM call), so its partial
+        # result is injected before the next main iteration.
+        mock_llm.add_response(content="Deadline handled.")
+        LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm
+
+        update = make_text_message('Run a deadline task', user_id=user_id)
+        await dp.process_update(update)
+        await asyncio.sleep(1.0)
+
+        spy.assert_sent_text_contains("Deadline handled.")
+
+        bg_content = "\n".join(
+            str(m.get('content', ''))
+            for c in mock_llm.calls for m in c['messages']
+            if '<background-results>' in str(m.get('content', ''))
+        )
+        assert 'deadline reached' in bg_content
+        assert 'completed' in bg_content  # delivered as a result, not killed as a timeout
+
     async def test_agent_mode_plan_sends_and_edits_message(self, bot_app):
         """Plan creation sends a message, step update edits it."""
         telegram_bot, dp, mock_bot = bot_app
@@ -634,6 +780,35 @@ class TestBackgroundTaskManager:
         results = {n.result for n in notifications}
         assert "result_a" in results
         assert "result_b" in results
+
+
+class TestAgentContextIsolation:
+
+    async def test_agent_context_isolated_between_concurrent_turns(self):
+        """Concurrent turns don't clobber each other's agent context; spawned tasks inherit their turn's context."""
+        from app.functions.agent_tools import agent_context_var
+
+        seen_by_child = {}
+
+        async def turn(name, hold):
+            token = agent_context_var.set(name)
+            try:
+                async def child():
+                    await asyncio.sleep(hold)
+                    seen_by_child[name] = agent_context_var.get()
+
+                child_task = asyncio.create_task(child())
+                await asyncio.sleep(hold / 2)
+                return child_task
+            finally:
+                agent_context_var.reset(token)
+
+        # Two overlapping "turns"; each child outlives its turn's reset
+        task_a, task_b = await asyncio.gather(turn('turn_a', 0.05), turn('turn_b', 0.02))
+        await asyncio.gather(task_a, task_b)
+
+        assert seen_by_child == {'turn_a': 'turn_a', 'turn_b': 'turn_b'}
+        assert agent_context_var.get() is None
 
 
 class TestPlanManager:

--- a/tests/helpers/mock_llm_client.py
+++ b/tests/helpers/mock_llm_client.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from unittest.mock import MagicMock
 from app.openai_helpers.llm_client import BaseLLMClient
 
@@ -26,7 +28,7 @@ class MockLLMClient(BaseLLMClient):
         self.calls = []
 
     def add_response(self, content, tool_calls=None, function_call=None,
-                     prompt_tokens=10, completion_tokens=20):
+                     prompt_tokens=10, completion_tokens=20, delay=None):
         self.responses.append({
             'content': content,
             'tool_calls': tool_calls,
@@ -34,6 +36,7 @@ class MockLLMClient(BaseLLMClient):
             'prompt_tokens': prompt_tokens,
             'completion_tokens': completion_tokens,
             'streaming': False,
+            'delay': delay,
         })
 
     def add_streaming_response(self, content_chunks, tool_calls=None,
@@ -57,6 +60,9 @@ class MockLLMClient(BaseLLMClient):
             raise ValueError("MockLLMClient: no more responses in queue")
 
         resp_data = self.responses.pop(0)
+
+        if resp_data.get('delay'):
+            await asyncio.sleep(resp_data['delay'])
 
         if additional_fields.get('stream') and resp_data.get('streaming'):
             return _build_streaming_response(resp_data, model)


### PR DESCRIPTION
Background tasks (SpawnTask sub-agents) almost always failed with a timeout: the 300s asyncio.wait_for covered an entire sub-agent run (up to 10 non-streaming LLM calls plus tool calls), each LLM call had no timeout of its own, and on expiry the coroutine was cancelled with all partial work lost.

- Sub-agent is now deadline-aware: checks remaining time between iterations, caps each LLM call with AGENT_SUB_AGENT_LLM_TIMEOUT, and returns a partial result (executed tools + last output) instead of being killed from outside. Manager's wait_for is only a backstop.
- Sub-agent starts with a snapshot of the parent conversation instead of cold, trimming any unfinished tool exchange.
- AGENT_BG_TASK_TIMEOUT raised 300 -> 900.
- Agent tool context moved from a shared class variable to a ContextVar, fixing cross-turn clobbering when a scheduled task fires during a user turn.
- Added lifecycle logging for background tasks and sub-agent iterations.