### PR TITLE
Add Tavily-backed web search and scraper agent tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ All configuration is in `settings.py`. The file has defaults at the top and loca
 - `app/openai_helpers/function_storage.py` — `FunctionStorage` registry, converts functions to OpenAI function/tool format
 - `app/context/function_manager.py` — decides which functions to register based on settings, user role, and context (e.g., VectorSearch only when documents are in context)
 - Built-in functions: `wolframalpha`, `dalle_3`, `todoist`, `obsidian_echo`, `save_user_settings`, `vectara_search`
+- Web agents (`app/functions/web_agents.py`, enabled via `ENABLE_WEB_AGENTS` + `TAVILY_API_KEY`): `web_search_agent` and `web_scraper_agent` — each runs an isolated LLM sub-agent (`app/runtime/web_agent_runner.py`, clean context, billed usage) equipped with internal Tavily tools (`tavily_search`/`tavily_extract`, client in `app/web/tavily_client.py`); registered in both `FunctionManager` and `AgentRuntime`
 - MCP integration: `app/functions/mcp/` — dynamically loads tools from configured MCP servers
 
 ### Bash Sandbox (agent mode)

--- a/app/context/function_manager.py
+++ b/app/context/function_manager.py
@@ -9,6 +9,7 @@ from app.functions.obsidian_echo import CreateObsidianNote
 from app.functions.save_user_settings import SaveUserSettings
 from app.functions.todoist import TodoistAddTask
 from app.functions.vectara_search import VectorSearch
+from app.functions.web_agents import WEB_AGENT_TOOLS
 from app.functions.wolframalpha import QueryWolframAlpha
 from app.openai_helpers.function_storage import FunctionStorage
 from app.storage.db import DB, User, MessageType
@@ -32,6 +33,9 @@ class FunctionManager:
 
         if settings.ENABLE_WOLFRAMALPHA:
             functions.append(QueryWolframAlpha)
+
+        if settings.ENABLE_WEB_AGENTS:
+            functions += WEB_AGENT_TOOLS
 
         return functions
 

--- a/app/functions/web_agents.py
+++ b/app/functions/web_agents.py
@@ -1,0 +1,184 @@
+"""Web agent tools: web_search_agent and web_scraper_agent.
+
+The two public tools each run an isolated LLM sub-agent (see
+app/runtime/web_agent_runner.py) equipped with low-level Tavily tools
+(tavily_search / tavily_extract). The sub-agent returns a synthesized
+answer with source links, which becomes the tool result for the main LLM.
+"""
+
+from typing import List, Optional
+
+from pydantic import Field
+
+import settings
+from app.functions.base import OpenAIFunction, OpenAIFunctionParams
+from app.runtime.web_agent_runner import run_web_agent
+from app.web.tavily_client import TavilyClient, TavilyError
+
+
+def _truncate(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    return text[:limit] + f"\n... (truncated, {len(text) - limit} chars omitted)"
+
+
+# --- Internal tools, registered only inside the web sub-agents ---
+
+class TavilySearchParams(OpenAIFunctionParams):
+    query: str = Field(..., description="search query")
+    max_results: int = Field(5, description="number of results to return (1-10)")
+
+
+class TavilySearch(OpenAIFunction):
+    PARAMS_SCHEMA = TavilySearchParams
+
+    async def run(self, params: TavilySearchParams) -> Optional[str]:
+        try:
+            response = await TavilyClient().search(params.query, max_results=params.max_results)
+        except TavilyError as e:
+            return f"Error: {e}"
+        results = response.get('results') or []
+        if not results:
+            return "No results found."
+        lines = []
+        for i, result in enumerate(results, 1):
+            lines.append(f"{i}. {result.get('title', '(no title)')}\n"
+                         f"   URL: {result.get('url', '')}\n"
+                         f"   {result.get('content', '')}")
+        return "\n".join(lines)
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "tavily_search"
+
+    @classmethod
+    def get_description(cls) -> str:
+        return "Search the web. Returns a list of results with title, URL and a content snippet."
+
+
+class TavilyExtractParams(OpenAIFunctionParams):
+    urls: List[str] = Field(..., description="URLs to extract content from (1-3 per call)")
+
+
+class TavilyExtract(OpenAIFunction):
+    PARAMS_SCHEMA = TavilyExtractParams
+
+    async def run(self, params: TavilyExtractParams) -> Optional[str]:
+        try:
+            response = await TavilyClient().extract(params.urls)
+        except TavilyError as e:
+            return f"Error: {e}"
+        parts = []
+        for result in response.get('results') or []:
+            content = _truncate(result.get('raw_content') or '', settings.WEB_AGENT_EXTRACT_MAX_CHARS)
+            parts.append(f"URL: {result.get('url', '')}\n{content}")
+        for failed in response.get('failed_results') or []:
+            url = failed.get('url', failed) if isinstance(failed, dict) else failed
+            parts.append(f"URL: {url}\nFailed to extract content.")
+        if not parts:
+            return "No content extracted."
+        return "\n\n---\n\n".join(parts)
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "tavily_extract"
+
+    @classmethod
+    def get_description(cls) -> str:
+        return "Extract the full page content from the given URLs."
+
+
+# --- Public tools, exposed to the main LLM ---
+
+WEB_SEARCH_AGENT_SYSTEM_PROMPT = """You are a web search agent. You are given a search task.
+
+Work method:
+1. Search the web with tavily_search. Reformulate or refine the query and search again if the first results are not good enough.
+2. If result snippets are not sufficient to answer, use tavily_extract on the 1-2 most promising URLs to read the full pages.
+3. When you have enough information, return the final answer.
+
+Your final answer must:
+- Be a concise synthesis of what you found, in the same language as the task.
+- Include a "Sources:" list with the URLs you actually used.
+- Say explicitly if you could not find reliable information."""
+
+
+class WebSearchAgentParams(OpenAIFunctionParams):
+    query: str = Field(..., description="natural language search query, include all relevant context")
+
+
+class WebSearchAgent(OpenAIFunction):
+    PARAMS_SCHEMA = WebSearchAgentParams
+
+    async def run(self, params: WebSearchAgentParams) -> Optional[str]:
+        return await run_web_agent(
+            self.user, self.db, self.context_manager, self.side_effects,
+            system_prompt=WEB_SEARCH_AGENT_SYSTEM_PROMPT,
+            task=params.query,
+            tool_classes=[TavilySearch, TavilyExtract],
+        )
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "web_search_agent"
+
+    @classmethod
+    def get_description(cls) -> str:
+        return ("Search the web for up-to-date information. Use for anything requiring current data, "
+                "news, or facts you're unsure about. Returns a synthesized answer with source links.")
+
+    @classmethod
+    def get_status_message(cls) -> str:
+        return 'Searching the web...'
+
+
+WEB_SCRAPER_AGENT_SYSTEM_PROMPT = """You are a web scraper agent. You are given a URL and optionally a task describing what to extract from it.
+
+Work method:
+1. Extract the page content with tavily_extract.
+2. If the task requires it and the page links to other pages you need, you may extract those too (at most a few).
+3. Return the requested information.
+
+Your final answer must:
+- Contain the extracted information or summary, in the same language as the task (or the page language if no task is given).
+- If a task is given, focus strictly on it; otherwise provide a general summary of the page.
+- Always mention the source URL.
+- Say explicitly if the page could not be extracted."""
+
+
+class WebScraperAgentParams(OpenAIFunctionParams):
+    url: str = Field(..., description="URL of the page to extract content from")
+    task: Optional[str] = Field(None, description="what exactly to extract or answer from the page; omit for a general summary")
+
+
+class WebScraperAgent(OpenAIFunction):
+    PARAMS_SCHEMA = WebScraperAgentParams
+
+    async def run(self, params: WebScraperAgentParams) -> Optional[str]:
+        task = f"URL: {params.url}"
+        if params.task:
+            task += f"\nTask: {params.task}"
+        else:
+            task += "\nTask: provide a general summary of the page content."
+        return await run_web_agent(
+            self.user, self.db, self.context_manager, self.side_effects,
+            system_prompt=WEB_SCRAPER_AGENT_SYSTEM_PROMPT,
+            task=task,
+            tool_classes=[TavilyExtract],
+        )
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "web_scraper_agent"
+
+    @classmethod
+    def get_description(cls) -> str:
+        return ("Extract and summarize content from a specific URL. Use when the user provides a link "
+                "or when you need the contents of a known page.")
+
+    @classmethod
+    def get_status_message(cls) -> str:
+        return 'Reading web page...'
+
+
+WEB_AGENT_TOOLS = [WebSearchAgent, WebScraperAgent]

--- a/app/runtime/agent_runtime.py
+++ b/app/runtime/agent_runtime.py
@@ -14,6 +14,7 @@ from app.functions.agent_tools import (
     SUB_AGENT_EXCLUDED_TOOLS,
 )
 from app.functions.bash_sandbox import SANDBOX_TOOLS
+from app.functions.web_agents import WEB_AGENT_TOOLS
 from app.functions.mcp.mcp_function_storage import MCPFunctionManager
 from app.llm_models import get_model_by_name
 from app.openai_helpers.anthropic_chatgpt import AnthropicChatGPT
@@ -103,6 +104,11 @@ class AgentRuntime:
         # Register bash sandbox tools
         if settings.ENABLE_BASH_SANDBOX:
             for tool_cls in SANDBOX_TOOLS:
+                function_storage.register(tool_cls)
+
+        # Register web agent tools
+        if settings.ENABLE_WEB_AGENTS:
+            for tool_cls in WEB_AGENT_TOOLS:
                 function_storage.register(tool_cls)
 
         # Create per-turn managers and load plan state

--- a/app/runtime/web_agent_runner.py
+++ b/app/runtime/web_agent_runner.py
@@ -1,0 +1,105 @@
+"""Isolated sub-agent loop for web agent tools (web_search_agent / web_scraper_agent).
+
+Unlike AgentRuntime._run_sub_agent, this runner starts with a clean context
+(only the task message), uses its own small tool set and records LLM usage
+for billing. It does not depend on the agent ContextVar, so the web agent
+tools work from both DefaultLLMRuntime and AgentRuntime.
+"""
+
+from typing import List
+
+import asyncio
+import logging
+import time
+
+import settings
+from app.context.dialog_manager import DialogUtils
+from app.llm_models import LLModel, get_model_by_name
+from app.openai_helpers.anthropic_chatgpt import AnthropicChatGPT
+from app.openai_helpers.chatgpt import ChatGPT
+from app.openai_helpers.function_storage import FunctionStorage
+from app.openai_helpers.utils import calculate_completion_usage_price
+from app.runtime.langfuse_utils import build_langfuse_metadata
+
+logger = logging.getLogger(__name__)
+
+
+async def run_web_agent(
+    user, db, context_manager, side_effects, *,
+    system_prompt: str,
+    task: str,
+    tool_classes: List[type],
+) -> str:
+    model_name = settings.WEB_AGENT_MODEL or user.current_model
+    llm_model = get_model_by_name(model_name)
+
+    function_storage = FunctionStorage()
+    for tool_cls in tool_classes:
+        function_storage.register(tool_cls)
+
+    langfuse_metadata = build_langfuse_metadata(user)
+    if model_name == LLModel.ANTHROPIC_CLAUDE_35_SONNET:
+        chatgpt = AnthropicChatGPT(llm_model, system_prompt, function_storage, langfuse_metadata=langfuse_metadata)
+    else:
+        chatgpt = ChatGPT(llm_model, system_prompt, function_storage, langfuse_metadata=langfuse_metadata)
+
+    messages = [DialogUtils.prepare_user_message(task)]
+    started_at = time.monotonic()
+    last_assistant_text = ''
+
+    def partial_result(reason: str) -> str:
+        result = f"Web agent stopped early: {reason}."
+        if last_assistant_text:
+            result += f" Partial findings:\n{last_assistant_text}"
+        return result
+
+    async def run_tool(function_name: str, arguments: str, tool_call_id) -> str:
+        try:
+            function_class = function_storage.get_function_class(function_name)
+            function = function_class(user, db, context_manager, side_effects, tool_call_id)
+            result = await function.run_str_args(arguments)
+        except Exception as e:
+            result = f"Error: {e}"
+        return result if result is not None else "(no output)"
+
+    for iteration in range(settings.WEB_AGENT_MAX_ITERATIONS):
+        try:
+            dialog_message, usage = await asyncio.wait_for(
+                chatgpt.send_messages(messages), timeout=settings.WEB_AGENT_LLM_TIMEOUT,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(f"[web-agent] LLM call timed out at iteration {iteration}")
+            return partial_result(f"LLM call timed out after {settings.WEB_AGENT_LLM_TIMEOUT}s")
+        except Exception as e:
+            logger.exception("[web-agent] LLM call failed")
+            return partial_result(f"LLM call failed: {e}")
+
+        price = calculate_completion_usage_price(usage.prompt_tokens, usage.completion_tokens, usage.model)
+        await db.create_completion_usage(
+            user.id, usage.prompt_tokens, usage.completion_tokens, usage.total_tokens, usage.model, price,
+        )
+
+        dialog_message = dialog_message.strip_thinking()
+        text_content = dialog_message.get_text_content() if dialog_message.content is not None else ''
+        if text_content:
+            last_assistant_text = text_content
+
+        if not dialog_message.tool_calls and not dialog_message.function_call:
+            logger.info(f"[web-agent] completed in {time.monotonic() - started_at:.1f}s, {iteration + 1} iteration(s)")
+            return text_content or "(empty response)"
+
+        messages.append(dialog_message)
+
+        if dialog_message.tool_calls:
+            for tool_call in dialog_message.tool_calls:
+                if tool_call.type != 'function':
+                    continue
+                result = await run_tool(tool_call.function.name, tool_call.function.arguments, tool_call.id)
+                messages.append(DialogUtils.prepare_tool_call_response(tool_call.id, result))
+        elif dialog_message.function_call:
+            fc = dialog_message.function_call
+            result = await run_tool(fc.name, fc.arguments, None)
+            messages.append(DialogUtils.prepare_function_response(fc.name, result))
+
+    logger.warning(f"[web-agent] iteration limit reached after {time.monotonic() - started_at:.1f}s")
+    return partial_result("iteration limit reached")

--- a/app/web/tavily_client.py
+++ b/app/web/tavily_client.py
@@ -1,0 +1,60 @@
+"""HTTP client for the Tavily API (https://docs.tavily.com).
+
+Used by the web search / scraper sub-agents. API key comes from
+settings.TAVILY_API_KEY and is sent as a Bearer token.
+"""
+
+from typing import List, Optional
+
+import httpx
+
+import settings
+
+
+class TavilyError(Exception):
+    pass
+
+
+def _extract_error(response: httpx.Response) -> str:
+    try:
+        data = response.json()
+        return data.get('detail', {}).get('error') or data.get('error') or response.text
+    except Exception:
+        return response.text or f'HTTP {response.status_code}'
+
+
+class TavilyClient:
+    BASE_URL = 'https://api.tavily.com'
+
+    def __init__(self, api_key: Optional[str] = None, base_url: Optional[str] = None):
+        self.api_key = api_key or settings.TAVILY_API_KEY
+        self.base_url = (base_url or self.BASE_URL).rstrip('/')
+
+    def _headers(self) -> dict:
+        return {'Authorization': f'Bearer {self.api_key}'}
+
+    async def _post(self, path: str, payload: dict) -> dict:
+        try:
+            async with httpx.AsyncClient(timeout=settings.WEB_AGENT_HTTP_TIMEOUT) as client:
+                response = await client.post(
+                    f'{self.base_url}{path}',
+                    json=payload,
+                    headers=self._headers(),
+                )
+        except httpx.HTTPError as e:
+            raise TavilyError(f'Tavily unavailable: {e}')
+        if response.status_code != 200:
+            raise TavilyError(_extract_error(response))
+        return response.json()
+
+    async def search(self, query: str, max_results: int = 5) -> dict:
+        """Returns {'results': [{'title', 'url', 'content', 'score'}, ...], ...}"""
+        return await self._post('/search', {
+            'query': query,
+            'max_results': max_results,
+            'search_depth': 'basic',
+        })
+
+    async def extract(self, urls: List[str]) -> dict:
+        """Returns {'results': [{'url', 'raw_content'}, ...], 'failed_results': [...]}"""
+        return await self._post('/extract', {'urls': urls})

--- a/settings.py
+++ b/settings.py
@@ -65,6 +65,15 @@ USER_ROLE_RAG = UserRole.BASIC  # minimum role needed to use RAG
 ENABLE_WOLFRAMALPHA = False
 WOLFRAMALPHA_APPID = 'YOUR_TOKEN'
 
+# Web agents (Tavily-backed web search / scraping sub-agents)
+ENABLE_WEB_AGENTS = False
+TAVILY_API_KEY = ''
+WEB_AGENT_MODEL = ''                 # model for web sub-agents; empty = user's current model
+WEB_AGENT_MAX_ITERATIONS = 8
+WEB_AGENT_LLM_TIMEOUT = 120          # seconds per web sub-agent LLM call
+WEB_AGENT_HTTP_TIMEOUT = 60          # httpx timeout for Tavily requests
+WEB_AGENT_EXTRACT_MAX_CHARS = 8000   # per-URL truncation of extracted content
+
 # Utility settings
 OPENAI_BASE_URL = 'https://api.openai.com/v1'
 MESSAGE_EXPIRATION_WINDOW = 60 * 60  # 1 hour

--- a/tests/e2e/test_web_agents.py
+++ b/tests/e2e/test_web_agents.py
@@ -1,0 +1,193 @@
+import asyncio
+import json
+
+import settings
+from app.openai_helpers.llm_client_factory import LLMClientFactory
+from app.web.tavily_client import TavilyClient, TavilyError
+from tests.helpers.mock_llm_client import MockLLMClient
+from tests.helpers.telegram_factory import make_text_message
+from tests.helpers.bot_spy import BotSpy
+
+
+async def _create_user_with_functions(telegram_bot, dp, user_id):
+    """Create a user via a first message and enable functions."""
+    mock_llm = MockLLMClient()
+    mock_llm.add_response("Hello!")
+    LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm
+
+    update = make_text_message('Hi', user_id=user_id)
+    await dp.process_update(update)
+    await asyncio.sleep(0.1)
+
+    user = await telegram_bot.db.get_user(user_id)
+    user.use_functions = True
+    await telegram_bot.db.update_user(user)
+
+
+class TestWebAgents:
+
+    async def test_web_search_agent(self, bot_app, db_pool, monkeypatch):
+        """Main LLM calls web_search_agent; the sub-agent searches via tavily_search
+        and returns a synthesized answer; sub-agent LLM usage is billed."""
+        telegram_bot, dp, mock_bot = bot_app
+        spy = BotSpy(mock_bot)
+        monkeypatch.setattr(settings, 'ENABLE_WEB_AGENTS', True)
+
+        user_id = 55551
+        await _create_user_with_functions(telegram_bot, dp, user_id)
+
+        search_calls = []
+
+        async def fake_search(self, query, max_results=5):
+            search_calls.append(query)
+            return {'results': [
+                {'title': 'Python 3.13 released', 'url': 'https://example.com/py313',
+                 'content': 'Python 3.13 was released in October 2024.', 'score': 0.99},
+            ]}
+
+        monkeypatch.setattr(TavilyClient, 'search', fake_search)
+
+        mock_llm = MockLLMClient()
+        # 1) main LLM -> tool call web_search_agent
+        mock_llm.add_response(
+            content=None,
+            tool_calls=[{
+                'id': 'call_ws1',
+                'function': {
+                    'name': 'web_search_agent',
+                    'arguments': json.dumps({'query': 'latest Python version'}),
+                },
+            }],
+        )
+        # 2) sub-agent -> tool call tavily_search
+        mock_llm.add_response(
+            content=None,
+            tool_calls=[{
+                'id': 'call_tv1',
+                'function': {
+                    'name': 'tavily_search',
+                    'arguments': json.dumps({'query': 'latest Python version', 'max_results': 5}),
+                },
+            }],
+        )
+        # 3) sub-agent -> final answer with sources
+        mock_llm.add_response("Latest is Python 3.13.\nSources:\n- https://example.com/py313")
+        # 4) main LLM -> final answer to the user
+        mock_llm.add_response("The latest Python version is 3.13.")
+        LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm
+
+        update = make_text_message('What is the latest Python version?', user_id=user_id)
+        await dp.process_update(update)
+        await asyncio.sleep(0.5)
+
+        assert search_calls == ['latest Python version']
+        spy.assert_sent_text_contains("The latest Python version is 3.13.")
+
+        # Sub-agent tool result was passed back to the sub-agent LLM
+        sub_agent_final_call = mock_llm.calls[2]
+        assert 'https://example.com/py313' in json.dumps(sub_agent_final_call['messages'])
+
+        # Billing: 1 (first message) + 1 (main tool call) + 2 (sub-agent) + 1 (main final)
+        usage_count = await db_pool.fetchval('SELECT COUNT(*) FROM chatgpttg.completion_usage')
+        assert usage_count == 5
+
+    async def test_web_scraper_agent(self, bot_app, monkeypatch):
+        """Main LLM calls web_scraper_agent; the sub-agent extracts the page
+        via tavily_extract and returns a summary."""
+        telegram_bot, dp, mock_bot = bot_app
+        spy = BotSpy(mock_bot)
+        monkeypatch.setattr(settings, 'ENABLE_WEB_AGENTS', True)
+
+        user_id = 55552
+        await _create_user_with_functions(telegram_bot, dp, user_id)
+
+        extract_calls = []
+
+        async def fake_extract(self, urls):
+            extract_calls.append(urls)
+            return {
+                'results': [{'url': urls[0], 'raw_content': 'Example Domain. This domain is for use in examples.'}],
+                'failed_results': [],
+            }
+
+        monkeypatch.setattr(TavilyClient, 'extract', fake_extract)
+
+        mock_llm = MockLLMClient()
+        mock_llm.add_response(
+            content=None,
+            tool_calls=[{
+                'id': 'call_sc1',
+                'function': {
+                    'name': 'web_scraper_agent',
+                    'arguments': json.dumps({'url': 'https://example.com', 'task': 'summarize the page'}),
+                },
+            }],
+        )
+        mock_llm.add_response(
+            content=None,
+            tool_calls=[{
+                'id': 'call_tv2',
+                'function': {
+                    'name': 'tavily_extract',
+                    'arguments': json.dumps({'urls': ['https://example.com']}),
+                },
+            }],
+        )
+        mock_llm.add_response("The page is a domain used in examples. Source: https://example.com")
+        mock_llm.add_response("Summary: example.com is a domain reserved for examples.")
+        LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm
+
+        update = make_text_message('Summarize https://example.com', user_id=user_id)
+        await dp.process_update(update)
+        await asyncio.sleep(0.5)
+
+        assert extract_calls == [['https://example.com']]
+        spy.assert_sent_text_contains("Summary: example.com is a domain reserved for examples.")
+
+    async def test_tavily_error_does_not_crash(self, bot_app, monkeypatch):
+        """TavilyError inside the sub-agent becomes a tool result string, the bot answers normally."""
+        telegram_bot, dp, mock_bot = bot_app
+        spy = BotSpy(mock_bot)
+        monkeypatch.setattr(settings, 'ENABLE_WEB_AGENTS', True)
+
+        user_id = 55553
+        await _create_user_with_functions(telegram_bot, dp, user_id)
+
+        async def failing_search(self, query, max_results=5):
+            raise TavilyError('invalid api key')
+
+        monkeypatch.setattr(TavilyClient, 'search', failing_search)
+
+        mock_llm = MockLLMClient()
+        mock_llm.add_response(
+            content=None,
+            tool_calls=[{
+                'id': 'call_ws2',
+                'function': {
+                    'name': 'web_search_agent',
+                    'arguments': json.dumps({'query': 'anything'}),
+                },
+            }],
+        )
+        mock_llm.add_response(
+            content=None,
+            tool_calls=[{
+                'id': 'call_tv3',
+                'function': {
+                    'name': 'tavily_search',
+                    'arguments': json.dumps({'query': 'anything'}),
+                },
+            }],
+        )
+        mock_llm.add_response("I could not search the web due to an error.")
+        mock_llm.add_response("Sorry, web search is unavailable right now.")
+        LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm
+
+        update = make_text_message('Search for anything', user_id=user_id)
+        await dp.process_update(update)
+        await asyncio.sleep(0.5)
+
+        # The error reached the sub-agent LLM as a tool result string
+        sub_agent_final_call = mock_llm.calls[2]
+        assert 'invalid api key' in json.dumps(sub_agent_final_call['messages'])
+        spy.assert_sent_text_contains("Sorry, web search is unavailable right now.")


### PR DESCRIPTION
Two new tools available in both normal and agent mode (gated by ENABLE_WEB_AGENTS + TAVILY_API_KEY):
- web_search_agent(query) — searches the web and returns a synthesized answer with source links
- web_scraper_agent(url, task?) — extracts and summarizes a page

Each runs an isolated LLM sub-agent (app/runtime/web_agent_runner.py) with a clean context and its own internal Tavily tools (tavily_search / tavily_extract, httpx client in app/web/tavily_client.py). Sub-agent LLM usage is recorded in completion_usage. Model is configurable via WEB_AGENT_MODEL, falling back to the user's current model.