### PR TITLE
Fix forwarded photos losing their image in context

### DIFF
--- a/app/bot/batched_input_handler.py
+++ b/app/bot/batched_input_handler.py
@@ -297,11 +297,25 @@ class BatchedInputHandler:
             username = f'Chat name "{username}"'
         else:
             username = None
-        forwarded_text = f'{username}:\n{message.text}' if username else message.text
+        if message.text:
+            forwarded_text = f'{username}:\n{message.text}' if username else message.text
+        else:
+            forwarded_text = f'{username}:' if username else None
+
+        images = None
+        if message.photo:
+            # largest photo
+            photo = message.photo[-1]
+            images = [ImageInput(
+                file_id=photo.file_id,
+                width=photo.width,
+                height=photo.height,
+            )]
 
         user_input.text_inputs.append(TextInput(
             text=forwarded_text,
             tg_message_id=message.message_id,
+            images=images,
         ))
 
     async def answer_message(self, first_message: types.Message, user: User, user_input: UserInput):

--- a/tests/e2e/test_forwarded_messages.py
+++ b/tests/e2e/test_forwarded_messages.py
@@ -53,3 +53,53 @@ class TestForwardedMessages:
             f"Expected 'John' in LLM context, got: {all_content}"
         assert 'forwarded content' in all_content, \
             f"Expected 'forwarded content' in LLM context, got: {all_content}"
+
+    async def test_forwarded_photo_keeps_image_in_context(self, bot_app):
+        """Forwarded photo is included in LLM context as an image, not just text."""
+        telegram_bot, dp, mock_bot = bot_app
+        spy = BotSpy(mock_bot)
+
+        user_id = 88881
+        photo_file_id = 'fwd-photo-file-id'
+
+        # Create user first
+        mock_llm = MockLLMClient()
+        mock_llm.add_response("Hello!")
+        LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm
+
+        update = make_text_message('Hi', user_id=user_id)
+        await dp.process_update(update)
+        await asyncio.sleep(0.1)
+
+        # Switch to a model with image processing capability
+        user = await telegram_bot.db.get_user(user_id)
+        user.current_model = 'gpt-4.1'
+        await telegram_bot.db.update_user(user)
+
+        mock_llm2 = MockLLMClient()
+        mock_llm2.add_response("This photo shows a cat.")
+        LLMClientFactory._model_clients['gpt-4.1'] = mock_llm2
+
+        # Forward photo (context only, forward_as_prompt defaults to False)
+        fwd_update = make_forward_message(
+            text=None,
+            forward_sender_name='John',
+            photo_file_id=photo_file_id,
+            user_id=user_id,
+        )
+        # Regular prompt message
+        prompt_update = make_text_message('What is on the photo?', user_id=user_id)
+
+        await dp.process_update(fwd_update)
+        await asyncio.sleep(0.05)
+        await dp.process_update(prompt_update)
+        await asyncio.sleep(0.2)
+
+        # LLM should receive context containing the forwarded photo as an image part
+        assert len(mock_llm2.calls) == 1
+        messages = mock_llm2.calls[0]['messages']
+        all_content = ' '.join(str(m.get('content', '')) for m in messages)
+        assert photo_file_id in all_content, \
+            f"Expected forwarded photo '{photo_file_id}' in LLM context, got: {all_content}"
+        assert 'John' in all_content, \
+            f"Expected 'John' in LLM context, got: {all_content}"

--- a/tests/helpers/telegram_factory.py
+++ b/tests/helpers/telegram_factory.py
@@ -124,7 +124,8 @@ def make_command_message(command, user_id=12345, chat_id=None, **kwargs):
 
 
 def make_forward_message(text, forward_sender_name=None, forward_from=None,
-                         user_id=12345, chat_id=None, **kwargs):
+                         user_id=12345, chat_id=None, photo_file_id=None, caption=None,
+                         **kwargs):
     if chat_id is None:
         chat_id = user_id
 
@@ -135,9 +136,21 @@ def make_forward_message(text, forward_sender_name=None, forward_from=None,
                                             if k in ('first_name', 'last_name', 'username')}),
         'chat': _make_chat_dict(chat_id),
         'date': int(time.time()),
-        'text': text,
         'forward_date': int(time.time()),
     }
+
+    if text is not None:
+        message_dict['text'] = text
+    if caption is not None:
+        message_dict['caption'] = caption
+    if photo_file_id is not None:
+        message_dict['photo'] = [{
+            'file_id': photo_file_id,
+            'file_unique_id': f'unique-{photo_file_id}',
+            'width': 800,
+            'height': 600,
+            'file_size': 1024,
+        }]
 
     if forward_from:
         message_dict['forward_from'] = {


### PR DESCRIPTION
Forwarded photos (with forward_as_prompt off) went through _handle_forwarded_message, which built a TextInput without images — the photo was silently dropped and the message was saved to context as text only. Regression from the runtime layer extraction (d9da368).

Now the forwarded message handler attaches ImageInput like the regular photo path, and a caption-less photo forward no longer produces a "Name:\nNone" text.