### PR TITLE
Speed up web agents: fast sub-agent model, tighter prompt, runner imp…

### DIFF
--- a/app/functions/web_agents.py
+++ b/app/functions/web_agents.py
@@ -90,15 +90,21 @@ class TavilyExtract(OpenAIFunction):
 
 # --- Public tools, exposed to the main LLM ---
 
-WEB_SEARCH_AGENT_SYSTEM_PROMPT = """You are a web search agent. You are given a search task.
+WEB_SEARCH_AGENT_SYSTEM_PROMPT = """You are a web search agent. Your job is to answer the given task using web search, quickly and efficiently.
 
-Work method:
-1. Search the web with tavily_search. Reformulate or refine the query and search again if the first results are not good enough.
-2. If result snippets are not sufficient to answer, use tavily_extract on the 1-2 most promising URLs to read the full pages.
-3. When you have enough information, return the final answer.
+Reasoning structure for every task:
+1. Decide: is this a simple query (a single fact or current value, e.g. "USD exchange rate today") or a complex one (requires digging into the topic, e.g. "find the best recipes")?
+2. Formulate the search query. Prefer searching in English — results are usually better — unless the task is tied to a specific language or region.
+3. Simple query: one tavily_search, answer directly from the snippets.
+   Complex query: tavily_search, then tavily_extract on the most promising URLs to read full pages.
+4. Synthesize everything you found into a complete answer.
+
+Be efficient — aim to finish within 2-3 turns:
+- Batch tool calls: issue multiple tavily_search calls in one turn if you need several angles, and extract up to 3 URLs in a single tavily_extract call.
+- Search again only if the results are truly unusable.
 
 Your final answer must:
-- Be a concise synthesis of what you found, in the same language as the task.
+- Be a synthesis of what you found, in the same language as the task.
 - Include a "Sources:" list with the URLs you actually used.
 - Say explicitly if you could not find reliable information."""
 
@@ -137,7 +143,7 @@ WEB_SCRAPER_AGENT_SYSTEM_PROMPT = """You are a web scraper agent. You are given 
 Work method:
 1. Extract the page content with tavily_extract.
 2. If the task requires it and the page links to other pages you need, you may extract those too (at most a few).
-3. Return the requested information.
+3. Return the requested information. Usually a single tavily_extract call is enough; aim to finish in 1-2 turns.
 
 Your final answer must:
 - Contain the extracted information or summary, in the same language as the task (or the page language if no task is given).

--- a/app/llm_models.py
+++ b/app/llm_models.py
@@ -38,6 +38,7 @@ class LLMCapabilities:
 class LLModel:
     GPT_35_TURBO = 'gpt-3.5-turbo'
     GPT_41 = 'gpt-4.1'
+    GPT_41_MINI = 'gpt-4.1-mini'
     ANTHROPIC_CLAUDE_35_SONNET = 'claude-3-5-sonnet-20240620'
     OPENROUTER_WIZARDLM2 = 'microsoft/wizardlm-2-8x22b'
 
@@ -109,6 +110,30 @@ def get_models():
                 model_price=LLMPrice(
                     input_tokens_price=Decimal('0.002'),
                     output_tokens_price=Decimal('0.008'),
+                ),
+                capabilities=LLMCapabilities(
+                    function_calling=True,
+                    image_processing=True,
+                    streaming_responses=True,
+                    tool_calling=True,
+                ),
+                base_url=settings.OPENAI_BASE_URL,
+                api_client=OpenAISpecificAsyncOpenAIClient,
+            ),
+            # hidden from the user-facing model picker (NOONE), used as the default web sub-agent model
+            LLModel.GPT_41_MINI: LLModel(
+                model_name=LLModel.GPT_41_MINI,
+                model_readable_name='GPT-4.1 mini',
+                api_key=settings.OPENAI_TOKEN,
+                minimum_user_role=UserRole.NOONE,
+                context_configuration=LLMContextConfiguration(
+                    short_term_memory_tokens=32 * 1024,
+                    summary_length=8 * 1024,
+                    hard_max_context_size=64 * 1024,
+                ),
+                model_price=LLMPrice(
+                    input_tokens_price=Decimal('0.0004'),
+                    output_tokens_price=Decimal('0.0016'),
                 ),
                 capabilities=LLMCapabilities(
                     function_calling=True,

--- a/app/runtime/web_agent_runner.py
+++ b/app/runtime/web_agent_runner.py
@@ -14,9 +14,10 @@ import time
 
 import settings
 from app.context.dialog_manager import DialogUtils
-from app.llm_models import LLModel, get_model_by_name
+from app.llm_models import get_model_by_name
 from app.openai_helpers.anthropic_chatgpt import AnthropicChatGPT
 from app.openai_helpers.chatgpt import ChatGPT
+from app.openai_helpers.llm_client import AnthropicAsyncClient
 from app.openai_helpers.function_storage import FunctionStorage
 from app.openai_helpers.utils import calculate_completion_usage_price
 from app.runtime.langfuse_utils import build_langfuse_metadata
@@ -31,14 +32,19 @@ async def run_web_agent(
     tool_classes: List[type],
 ) -> str:
     model_name = settings.WEB_AGENT_MODEL or user.current_model
-    llm_model = get_model_by_name(model_name)
+    try:
+        llm_model = get_model_by_name(model_name)
+    except ValueError:
+        logger.warning(f"[web-agent] model {model_name!r} not available, falling back to user model")
+        model_name = user.current_model
+        llm_model = get_model_by_name(model_name)
 
     function_storage = FunctionStorage()
     for tool_cls in tool_classes:
         function_storage.register(tool_cls)
 
     langfuse_metadata = build_langfuse_metadata(user)
-    if model_name == LLModel.ANTHROPIC_CLAUDE_35_SONNET:
+    if issubclass(llm_model.api_client, AnthropicAsyncClient):
         chatgpt = AnthropicChatGPT(llm_model, system_prompt, function_storage, langfuse_metadata=langfuse_metadata)
     else:
         chatgpt = ChatGPT(llm_model, system_prompt, function_storage, langfuse_metadata=langfuse_metadata)
@@ -62,7 +68,16 @@ async def run_web_agent(
             result = f"Error: {e}"
         return result if result is not None else "(no output)"
 
-    for iteration in range(settings.WEB_AGENT_MAX_ITERATIONS):
+    # one extra iteration for finalization: when the tool call budget is exhausted,
+    # the model gets a last chance to answer from what it has instead of returning a partial result
+    max_iterations = settings.WEB_AGENT_MAX_ITERATIONS
+    for iteration in range(max_iterations + 1):
+        is_finalization = iteration == max_iterations
+        if is_finalization:
+            messages.append(DialogUtils.prepare_user_message(
+                "You have reached the tool call limit. Provide your final answer now "
+                "based on what you already have. Do not call any more tools."
+            ))
         try:
             dialog_message, usage = await asyncio.wait_for(
                 chatgpt.send_messages(messages), timeout=settings.WEB_AGENT_LLM_TIMEOUT,
@@ -88,13 +103,17 @@ async def run_web_agent(
             logger.info(f"[web-agent] completed in {time.monotonic() - started_at:.1f}s, {iteration + 1} iteration(s)")
             return text_content or "(empty response)"
 
+        if is_finalization:
+            break
+
         messages.append(dialog_message)
 
         if dialog_message.tool_calls:
-            for tool_call in dialog_message.tool_calls:
-                if tool_call.type != 'function':
-                    continue
-                result = await run_tool(tool_call.function.name, tool_call.function.arguments, tool_call.id)
+            function_calls = [tc for tc in dialog_message.tool_calls if tc.type == 'function']
+            results = await asyncio.gather(*[
+                run_tool(tc.function.name, tc.function.arguments, tc.id) for tc in function_calls
+            ])
+            for tool_call, result in zip(function_calls, results):
                 messages.append(DialogUtils.prepare_tool_call_response(tool_call.id, result))
         elif dialog_message.function_call:
             fc = dialog_message.function_call

--- a/settings.py
+++ b/settings.py
@@ -67,7 +67,7 @@ WOLFRAMALPHA_APPID = 'YOUR_TOKEN'
 # Web agents (Tavily-backed web search / scraping sub-agents)
 ENABLE_WEB_AGENTS = False
 TAVILY_API_KEY = ''
-WEB_AGENT_MODEL = ''                 # model for web sub-agents; empty = user's current model
+WEB_AGENT_MODEL = 'gpt-4.1-mini'     # model for web sub-agents; empty = user's current model
 WEB_AGENT_MAX_ITERATIONS = 8
 WEB_AGENT_LLM_TIMEOUT = 120          # seconds per web sub-agent LLM call
 WEB_AGENT_HTTP_TIMEOUT = 60          # httpx timeout for Tavily requests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,7 @@ settings.ENABLE_WOLFRAMALPHA = False
 settings.ENABLE_USER_ROLE_MANAGER_CHAT = False
 settings.MCP_SERVERS = []
 settings.EXTRA_MODELS = []
+settings.WEB_AGENT_MODEL = ''  # web sub-agents use the user's model, which tests mock
 settings.IMAGE_PROXY_URL = 'http://localhost'
 settings.IMAGE_PROXY_PORT = 18321
 

--- a/tests/e2e/test_web_agents.py
+++ b/tests/e2e/test_web_agents.py
@@ -191,3 +191,232 @@ class TestWebAgents:
         sub_agent_final_call = mock_llm.calls[2]
         assert 'invalid api key' in json.dumps(sub_agent_final_call['messages'])
         spy.assert_sent_text_contains("Sorry, web search is unavailable right now.")
+
+    async def test_web_agent_model_setting(self, bot_app, db_pool, monkeypatch):
+        """WEB_AGENT_MODEL routes the sub-agent to its own model, main dialog stays on the user's model."""
+        telegram_bot, dp, mock_bot = bot_app
+        spy = BotSpy(mock_bot)
+        monkeypatch.setattr(settings, 'ENABLE_WEB_AGENTS', True)
+        monkeypatch.setattr(settings, 'WEB_AGENT_MODEL', 'gpt-4.1-mini')
+
+        user_id = 55554
+        await _create_user_with_functions(telegram_bot, dp, user_id)
+
+        async def fake_search(self, query, max_results=5):
+            return {'results': [
+                {'title': 'Result', 'url': 'https://example.com/r', 'content': 'Some content.', 'score': 0.9},
+            ]}
+
+        monkeypatch.setattr(TavilyClient, 'search', fake_search)
+
+        main_llm = MockLLMClient()
+        main_llm.add_response(
+            content=None,
+            tool_calls=[{
+                'id': 'call_ws3',
+                'function': {
+                    'name': 'web_search_agent',
+                    'arguments': json.dumps({'query': 'anything'}),
+                },
+            }],
+        )
+        main_llm.add_response("Done.")
+        LLMClientFactory._model_clients['gpt-3.5-turbo'] = main_llm
+
+        sub_llm = MockLLMClient()
+        sub_llm.add_response(
+            content=None,
+            tool_calls=[{
+                'id': 'call_tv4',
+                'function': {
+                    'name': 'tavily_search',
+                    'arguments': json.dumps({'query': 'anything'}),
+                },
+            }],
+        )
+        sub_llm.add_response("Found it.\nSources:\n- https://example.com/r")
+        LLMClientFactory._model_clients['gpt-4.1-mini'] = sub_llm
+
+        update = make_text_message('Search for anything', user_id=user_id)
+        await dp.process_update(update)
+        await asyncio.sleep(0.5)
+
+        assert [call['model'] for call in sub_llm.calls] == ['gpt-4.1-mini', 'gpt-4.1-mini']
+        spy.assert_sent_text_contains("Done.")
+
+        # Sub-agent usage is billed under the sub-agent model
+        models = await db_pool.fetch('SELECT model FROM chatgpttg.completion_usage')
+        assert sum(1 for row in models if row['model'] == 'gpt-4.1-mini') == 2
+
+    async def test_web_agent_model_fallback(self, bot_app, monkeypatch):
+        """Unknown WEB_AGENT_MODEL falls back to the user's current model instead of crashing."""
+        telegram_bot, dp, mock_bot = bot_app
+        spy = BotSpy(mock_bot)
+        monkeypatch.setattr(settings, 'ENABLE_WEB_AGENTS', True)
+        monkeypatch.setattr(settings, 'WEB_AGENT_MODEL', 'nonexistent-model')
+
+        user_id = 55555
+        await _create_user_with_functions(telegram_bot, dp, user_id)
+
+        async def fake_search(self, query, max_results=5):
+            return {'results': [
+                {'title': 'Result', 'url': 'https://example.com/r', 'content': 'Some content.', 'score': 0.9},
+            ]}
+
+        monkeypatch.setattr(TavilyClient, 'search', fake_search)
+
+        mock_llm = MockLLMClient()
+        mock_llm.add_response(
+            content=None,
+            tool_calls=[{
+                'id': 'call_ws4',
+                'function': {
+                    'name': 'web_search_agent',
+                    'arguments': json.dumps({'query': 'anything'}),
+                },
+            }],
+        )
+        mock_llm.add_response(
+            content=None,
+            tool_calls=[{
+                'id': 'call_tv5',
+                'function': {
+                    'name': 'tavily_search',
+                    'arguments': json.dumps({'query': 'anything'}),
+                },
+            }],
+        )
+        mock_llm.add_response("Found it.\nSources:\n- https://example.com/r")
+        mock_llm.add_response("Here is your answer.")
+        LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm
+
+        update = make_text_message('Search for anything', user_id=user_id)
+        await dp.process_update(update)
+        await asyncio.sleep(0.5)
+
+        spy.assert_sent_text_contains("Here is your answer.")
+
+    async def test_parallel_tool_calls(self, bot_app, monkeypatch):
+        """Multiple tool calls in one sub-agent turn all execute, responses keep tool call order."""
+        telegram_bot, dp, mock_bot = bot_app
+        spy = BotSpy(mock_bot)
+        monkeypatch.setattr(settings, 'ENABLE_WEB_AGENTS', True)
+
+        user_id = 55556
+        await _create_user_with_functions(telegram_bot, dp, user_id)
+
+        async def fake_search(self, query, max_results=5):
+            return {'results': [
+                {'title': f'Result for {query}', 'url': f'https://example.com/{query}',
+                 'content': f'Content about {query}.', 'score': 0.9},
+            ]}
+
+        monkeypatch.setattr(TavilyClient, 'search', fake_search)
+
+        mock_llm = MockLLMClient()
+        mock_llm.add_response(
+            content=None,
+            tool_calls=[{
+                'id': 'call_ws5',
+                'function': {
+                    'name': 'web_search_agent',
+                    'arguments': json.dumps({'query': 'compare A and B'}),
+                },
+            }],
+        )
+        # Sub-agent issues two searches in a single turn
+        mock_llm.add_response(
+            content=None,
+            tool_calls=[
+                {
+                    'id': 'call_tv6',
+                    'function': {
+                        'name': 'tavily_search',
+                        'arguments': json.dumps({'query': 'topicA'}),
+                    },
+                },
+                {
+                    'id': 'call_tv7',
+                    'function': {
+                        'name': 'tavily_search',
+                        'arguments': json.dumps({'query': 'topicB'}),
+                    },
+                },
+            ],
+        )
+        mock_llm.add_response("A vs B comparison.\nSources:\n- https://example.com/topicA\n- https://example.com/topicB")
+        mock_llm.add_response("Comparison ready.")
+        LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm
+
+        update = make_text_message('Compare A and B', user_id=user_id)
+        await dp.process_update(update)
+        await asyncio.sleep(0.5)
+
+        spy.assert_sent_text_contains("Comparison ready.")
+
+        # Both tool results reached the sub-agent, in tool call order
+        sub_agent_final_messages = mock_llm.calls[2]['messages']
+        tool_messages = [m for m in sub_agent_final_messages if m.get('role') == 'tool']
+        assert [m['tool_call_id'] for m in tool_messages] == ['call_tv6', 'call_tv7']
+        assert 'topicA' in tool_messages[0]['content']
+        assert 'topicB' in tool_messages[1]['content']
+
+    async def test_finalization_on_iteration_limit(self, bot_app, monkeypatch):
+        """When the iteration limit is hit, the sub-agent gets one nudged finalization call
+        and the user receives a real answer instead of 'stopped early'."""
+        telegram_bot, dp, mock_bot = bot_app
+        spy = BotSpy(mock_bot)
+        monkeypatch.setattr(settings, 'ENABLE_WEB_AGENTS', True)
+        monkeypatch.setattr(settings, 'WEB_AGENT_MAX_ITERATIONS', 1)
+
+        user_id = 55557
+        await _create_user_with_functions(telegram_bot, dp, user_id)
+
+        async def fake_search(self, query, max_results=5):
+            return {'results': [
+                {'title': 'Result', 'url': 'https://example.com/r', 'content': 'Some content.', 'score': 0.9},
+            ]}
+
+        monkeypatch.setattr(TavilyClient, 'search', fake_search)
+
+        mock_llm = MockLLMClient()
+        mock_llm.add_response(
+            content=None,
+            tool_calls=[{
+                'id': 'call_ws6',
+                'function': {
+                    'name': 'web_search_agent',
+                    'arguments': json.dumps({'query': 'anything'}),
+                },
+            }],
+        )
+        # Sub-agent iteration 1 (the whole budget) — wants a tool call
+        mock_llm.add_response(
+            content=None,
+            tool_calls=[{
+                'id': 'call_tv8',
+                'function': {
+                    'name': 'tavily_search',
+                    'arguments': json.dumps({'query': 'anything'}),
+                },
+            }],
+        )
+        # Finalization call — answers with text
+        mock_llm.add_response("Best effort answer.\nSources:\n- https://example.com/r")
+        mock_llm.add_response("Here is the answer.")
+        LLMClientFactory._model_clients['gpt-3.5-turbo'] = mock_llm
+
+        update = make_text_message('Search for anything', user_id=user_id)
+        await dp.process_update(update)
+        await asyncio.sleep(0.5)
+
+        spy.assert_sent_text_contains("Here is the answer.")
+
+        # The finalization call saw the nudge message and the tool result
+        finalization_messages = mock_llm.calls[2]['messages']
+        assert 'tool call limit' in json.dumps(finalization_messages)
+
+        # The main LLM got the real answer, not a partial-result marker
+        main_final_messages = json.dumps(mock_llm.calls[3]['messages'])
+        assert 'Best effort answer.' in main_final_messages
+        assert 'stopped early' not in main_final_messages


### PR DESCRIPTION
…rovements

- Add gpt-4.1-mini to llm_models (hidden from user picker via NOONE role) and make it the default WEB_AGENT_MODEL, with graceful fallback to the user's model when unavailable
- Rewrite web search agent prompt: simple/complex query classification, search in English, 2-3 turn budget, batched tool calls
- Run tool calls of one iteration concurrently via asyncio.gather
- On iteration limit, make one final nudged LLM call so the user gets a real answer instead of "stopped early" partial findings
- Select Anthropic client by the model's api_client instead of a hardcoded model name